### PR TITLE
fix(nvim): ftdetect/djot.lua in Windows

### DIFF
--- a/AppData/Local/nvim/ftdetect/djot.lua.tmpl
+++ b/AppData/Local/nvim/ftdetect/djot.lua.tmpl
@@ -1,1 +1,1 @@
-{{- include "dot_config/nvim/ftdetect/djot.lua.json" -}}
+{{- include "dot_config/nvim/ftdetect/djot.lua" -}}


### PR DESCRIPTION
Fix #503