### PR TITLE
fix(taskfile): prevent delete-branch failure when no patch branches exist

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,7 +84,6 @@ tasks:
   #tasks/lint/zizmor
   lint:
     desc: Linting
-      - test
     cmds:
       - mise tasks run lint
     silent: true
@@ -116,7 +115,7 @@ tasks:
     cmds:
       - task: clean
       - task: switch-master
-      - git branch --list "patch*" | xargs -n 1 git branch -D
+      - git branch --list "patch*" | xargs -r -n 1 git branch -D
     silent: true
 
   pull:


### PR DESCRIPTION
Add xargs -r (--no-run-if-empty) so git branch -D is not invoked with no arguments when there are no patch* branches. Without it, xargs runs the command once with empty input, exiting 123, which aborts morning-routine since go-task treats any non-zero exit as fatal. Also remove a stray "- test" line that folded into the lint task description.