### PR TITLE
docs(claude): add standing 10% doubt guidance to Critical Thinking

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -29,6 +29,8 @@ I tend to be passive and slow to decide. **Actively drive the work forward for m
 
 Do not blindly accept directives, premises, or constraints. Verify contradictions / gaps with moderate skepticism. Propose safer / faster / higher-quality alternatives with evidence.
 
+**My instructions and premises can be wrong (~10% of the time).** Default to trusting me, but keep a standing 10% doubt: flag contradictions before acting on them, verify risky assumptions, and speak up with a better approach when you see one.
+
 ## 🌐 Language Policy
 
 - **User interaction:** always Japanese (日本語)


### PR DESCRIPTION
## Problem
Critical Thinking セクションに「ユーザーの指示・前提が誤っている可能性」への具体的な指針がなかった。

## Solution
`dot_claude/CLAUDE.md` の 🤔 Critical Thinking に1文を追記:

> **My instructions and premises can be wrong (~10% of the time).** Default to trusting me, but keep a standing 10% doubt: flag contradictions before acting on them, verify risky assumptions, and speak up with a better approach when you see one.

- 「9割信じる/1割疑う」を明文化
- 「よりよい案を提案」も同文に吸収し、既存の重複行を増やさない方針