### PR TITLE
chore(update): sort claude settings.json keys on chezmoi add

### DIFF
--- a/.mise/tasks/update/chezmoi
+++ b/.mise/tasks/update/chezmoi
@@ -53,6 +53,15 @@ deno fmt dot_config/nvim/dotfyle.json
 # sunbeam
 chezmoi add ~/.config/sunbeam/sunbeam.json
 
+# claude code
+# Claude Code rewrites settings.json every session (keys reordered, runtime
+# state appended), so a raw `git diff` is pure reordering noise. Pull it in and
+# sort keys with `jq -S` so diffs stay semantic. Arrays (e.g. permissions.allow)
+# keep their order; only object keys are sorted.
+chezmoi add ~/.claude/settings.json
+jq -S . dot_claude/private_settings.json >dot_claude/private_settings.json.tmp &&
+    mv dot_claude/private_settings.json.tmp dot_claude/private_settings.json
+
 # brow6el configs
 chezmoi add ~/.brow6el/bookmarks
 chezmoi add ~/.brow6el/userscripts

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -1,11 +1,11 @@
 {
   "cleanupPeriodDays": 30,
-  "env": {
-    "CLAUDE_CODE_HIDE_ACCOUNT_INFO": "1"
-  },
   "enabledPlugins": {
     "i-have-adhd@i-have-adhd": true,
     "obsidian@obsidian-skills": true
+  },
+  "env": {
+    "CLAUDE_CODE_HIDE_ACCOUNT_INFO": "1"
   },
   "extraKnownMarketplaces": {
     "dotnet-agent-skills": {

--- a/maskfile.md
+++ b/maskfile.md
@@ -286,6 +286,15 @@ deno fmt dot_config/nvim/dotfyle.json
 # sunbeam
 chezmoi add ~/.config/sunbeam/sunbeam.json
 
+# claude code
+# Claude Code rewrites settings.json every session (keys reordered, runtime
+# state appended), so a raw `git diff` is pure reordering noise. Pull it in and
+# sort keys with `jq -S` so diffs stay semantic. Arrays (e.g. permissions.allow)
+# keep their order; only object keys are sorted.
+chezmoi add ~/.claude/settings.json
+jq -S . dot_claude/private_settings.json >dot_claude/private_settings.json.tmp &&
+    mv dot_claude/private_settings.json.tmp dot_claude/private_settings.json
+
 # brow6el configs
 chezmoi add ~/.brow6el/bookmarks
 chezmoi add ~/.brow6el/userscripts


### PR DESCRIPTION
Claude Code rewrites ~/.claude/settings.json every session (keys reordered,
runtime state appended), making a raw git diff pure reordering noise. Pull it
in and normalize with jq -S in both the mise update task and the maskfile
update section. Arrays keep their order; only object keys are sorted.