### PR TITLE
feat(pueue): add Windows config and drop deprecated key

### DIFF
--- a/AppData/Roaming/pueue/pueue.yml.tmpl
+++ b/AppData/Roaming/pueue/pueue.yml.tmpl
@@ -1,0 +1,22 @@
+---
+client:
+  read_local_logs: true
+  show_confirmation_questions: false
+  show_expanded_aliases: false
+  dark_mode: false
+  max_status_lines: ~
+daemon:
+  default_parallel_tasks: 1
+  pause_group_on_failure: false
+  pause_all_on_failure: false
+  callback: ~
+shared:
+  # Windows does not support unix sockets; the daemon is reached over TCP.
+  pueue_directory: {{ .chezmoi.homeDir }}\AppData\Roaming\pueue
+  host: 127.0.0.1
+  port: "6924"
+  daemon_cert: {{ .chezmoi.homeDir }}\AppData\Roaming\pueue\certs\daemon.cert
+  daemon_key: {{ .chezmoi.homeDir }}\AppData\Roaming\pueue\certs\daemon.key
+  shared_secret_path: {{ .chezmoi.homeDir }}\AppData\Roaming\pueue\shared_secret
+
+# vim:ft=yaml.chezmoitmpl

--- a/AppData/Roaming/pueue/pueue.yml.tmpl
+++ b/AppData/Roaming/pueue/pueue.yml.tmpl
@@ -6,7 +6,6 @@ client:
   dark_mode: false
   max_status_lines: ~
 daemon:
-  default_parallel_tasks: 1
   pause_group_on_failure: false
   pause_all_on_failure: false
   callback: ~

--- a/dot_config/pueue/pueue.yml.tmpl
+++ b/dot_config/pueue/pueue.yml.tmpl
@@ -6,7 +6,6 @@ client:
   dark_mode: false
   max_status_lines: ~
 daemon:
-  default_parallel_tasks: 1
   pause_group_on_failure: false
   pause_all_on_failure: false
   callback: ~


### PR DESCRIPTION
## Problem
- pueue の設定が Linux 用の `dot_config/pueue/pueue.yml.tmpl` のみで、Windows 側（%APPDATA%\pueue）に設定が存在しなかった。既存テンプレートは Unix socket / Unix パス前提のため Windows では利用不可。
- 両設定に残っていた `daemon.default_parallel_tasks` は pueue 4.x の config スキーマに存在しない廃止キー（並列数はグループ単位のランタイム状態に移行）。黙って無視されるだけの死にキー。

## Solution
1. **Windows 用テンプレート追加** `AppData/Roaming/pueue/pueue.yml.tmpl`（公式 Wiki Configuration 準拠）
   - Windows は Unix socket 非対応 → `use_unix_socket` / `unix_socket_path` を削除し `host` + `port` の TCP 通信を使用
   - パスを Windows 形式（`{{ .chezmoi.homeDir }}\AppData\Roaming\pueue`）に変更
   - `AppData/**` は `.chezmoiignore.tmpl` により Windows でのみ展開
2. **廃止キー削除** Linux / Windows 両テンプレートから `default_parallel_tasks` を除去

## Verification
- pueue 4.0.4 実機で `pueue --config <rendered> status` により両設定のパースを確認
- `chezmoi execute-template` でテンプレート構文を検証

## Note
pueued の常駐起動は Windows では systemd を使えないため本 PR の対象外（別途タスクスケジューラ等が必要）。