### PR TITLE
docs(claude): add recommendation principles section

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -31,6 +31,18 @@ Do not blindly accept directives, premises, or constraints. Verify contradiction
 
 **My instructions and premises can be wrong (~10% of the time).** Default to trusting me, but keep a standing 10% doubt: flag contradictions before acting on them, verify risky assumptions, and speak up with a better approach when you see one.
 
+## 💡 Recommendation Principles
+
+- **Always include the reason.** When recommending an item, method, or approach,
+  add one sentence explaining *why it's needed*.
+- **Include a concrete usage image** (shape, how it's attached/worn, how it fits
+  into the workflow) alongside the recommendation.
+- **When recommending a combination (A + B + C), spell out each item's role and
+  how they relate to each other.** If a single item looks sufficient on its own,
+  explain why the combination is necessary.
+- Avoid phrasing that only makes sense once I've inferred the rationale myself.
+  You provide the reasoning; don't leave me to reconstruct it.
+
 ## 🌐 Language Policy
 
 - **User interaction:** always Japanese (日本語)


### PR DESCRIPTION
## Summary
- `dot_claude/CLAUDE.md` に「Recommendation Principles」セクションを追加
- 提案時に理由・具体的な使用イメージ・複数項目を組み合わせる際の役割説明を求めるガイドラインを明文化
- 既存セクションと表記を揃えるため英語で記述

## Test plan
- [x] `dot_claude/CLAUDE.md` の該当セクションが英語で追加されていること
- [x] `chezmoi apply` 後に `~/.claude/CLAUDE.md` へ反映されること