### PR TITLE
fix(ci): restore textlint and spell check on pnpm v11

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,9 +1,13 @@
 name: Spell Check
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+  # NOTE: no paths filter — typos scans the whole repository, so any file can
+  # introduce a hit
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/stylua-lint.yml
+++ b/.github/workflows/stylua-lint.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # NOTE: we recommend pinning to a specific version in case of formatting changes
-          version: latest
+          # renovate: datasource=github-releases depName=JohnnyMorganz/StyLua extractVersion=^v(?<version>.*)$
+          version: 2.5.2
           # CLI arguments
           args: --check .

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -1,14 +1,28 @@
 name: Run textlint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+    # NOTE: keep in sync with the pull_request paths below
     paths:
       - "**.md"
+      - ".github/workflows/textlint.yml"
+      - ".textlintrc.json"
+      - ".textlintignore"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   pull_request:
     paths:
       - "**.md"
+      - ".github/workflows/textlint.yml"
+      - ".textlintrc.json"
+      - ".textlintignore"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions: {}
 

--- a/.github/workflows/textlint.yml
+++ b/.github/workflows/textlint.yml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - "**.md"
+  pull_request:
+    paths:
+      - "**.md"
 
 permissions: {}
 
@@ -25,10 +28,9 @@ jobs:
         with:
           node-version: 24
 
+      # NOTE: the pnpm version comes from the "packageManager" field in package.json
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: latest
 
       - name: Install dependencies
         run: |

--- a/.typos.toml
+++ b/.typos.toml
@@ -32,6 +32,8 @@ iterm = "iterm"
 # dot_config/fish/completions/srgn.fish
 # `Hashi` is HashiCorp
 Hashi = "Hashi"
+# Todoist MCP tool name in dot_claude/private_settings.json
+uncomplete = "uncomplete"
 
 [files]
 extend-exclude = [

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@11.17.0",
   "devDependencies": {
     "cspell": "^10.0.0",
     "cspell-dict-yaju": "^0.0.3",
@@ -13,8 +14,5 @@
     "lint:prettier": "prettier --check .",
     "fmt:prettier": "prettier --write .",
     "commit": "cz"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["lefthook"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
-onlyBuiltDependencies:
-  - lefthook
+# pnpm v11 replaced `onlyBuiltDependencies` with `allowBuilds`.
+# lefthook needs its postinstall to install the git hooks.
+allowBuilds:
+  lefthook: true


### PR DESCRIPTION
## Problem

Both the textlint and Spell Check workflows are red on master.

**textlint** never reached textlint at all — `pnpm install` aborted:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: lefthook@2.1.10
```

`pnpm/action-setup` was set to `version: latest`, so CI moved to pnpm v11 on
its own. v11 stopped reading the `pnpm` field in `package.json` *and* replaced
`onlyBuiltDependencies` with `allowBuilds`, which invalidated both places
lefthook's build was approved. This stayed invisible locally because
`~/.npmrc` sets `ignore-scripts=true`, which suppresses the error.

**Spell Check** is unrelated: typos flags `uncomplete` in the Todoist MCP tool
matcher added in 89a5240c.

## Solution

- `pnpm-workspace.yaml`: `onlyBuiltDependencies` -> `allowBuilds: {lefthook: true}`
- `package.json`: drop the dead `pnpm` field, add `packageManager: pnpm@11.17.0`
  so CI and local development share one pinned version
- `stylua-lint.yml`: pin stylua to 2.5.2 — the action's own comment recommended
  pinning, and it was the last remaining `version: latest`
- Both pins carry renovate annotations, so updates still arrive as PRs
- `textlint.yml`: add a `pull_request` trigger, matching `stylua-lint.yml`, so
  this class of breakage surfaces before master. The `push` trigger on master
  is kept for direct pushes.
- `.typos.toml`: allow `uncomplete`
- `textlint.yml`: widen the paths filter to the workflow, the textlint config
  and the pnpm manifests. It only matched `**.md`, so a change that breaks the
  job could not trigger it — which is why this PR reported no checks at first.
  Also add `workflow_dispatch`.
- `spell-check.yml`: add a `pull_request` trigger and `workflow_dispatch`. The
  `uncomplete` hit only surfaced after it reached master. No paths filter —
  typos scans the whole repository, so any file can introduce a hit.

## Verification

Run locally with the user `~/.npmrc` neutralised to reproduce CI conditions:

- `pnpm install` — exit 0, lefthook postinstall runs
- `textlint ./*.md` — exit 0
- `typos ./ --config ./.typos.toml` — exit 0
- `prettier --check` on all five changed files — pass

