### PR TITLE
feat(claude): check settings env keys against the binary at session start

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -8,6 +8,11 @@
 !.claude/.editorconfig
 !.claude/rules
 !.claude/rules/**
+# Hooks are config, not runtime state: settings.json references these by
+# absolute path, so leaving them unmanaged makes a fresh apply produce a
+# settings.json whose SessionStart hooks point at files that do not exist.
+!.claude/hooks
+!.claude/hooks/**
 
 # HACK: Now configuration... 2026年3月17日
 .config/elvish/**

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -132,7 +132,7 @@ Use **situation-first analysis (A-B-C) plus "How, not Why":**
 A 🔴 fixed in some other repo and never written down is a fix whose recurrence
 nobody will ever check. So when step 1 tags a problem 🔴, file a record:
 
-- Repo: `~/ghq/github.com/mimikun/mimikun.kabeuti/` — read its `handover.md`
+- Repo: `~/ghq/github.com/mimikun/mimikun.problem-solving/` — read its `handover.md`
   first; it carries the rules that keep this from rotting.
 - Copy `records/_TEMPLATE.md` to `records/Pxx-<slug>.md`. List the directory
   first so `Pxx` does not collide.
@@ -162,7 +162,7 @@ nobody will ever check. So when step 1 tags a problem 🔴, file a record:
 - This conversational process trains **noticing** and **structuring** only.
 - Step 5's **execution** happens in the real world — reading me is not the same as doing it.
 
-Related memory: `projects/-home-mimikun-ghq-github-com-mimikun-mimikun-kabeuti/memory/problem-awareness-growth.md`
+Related memory: `projects/-home-mimikun-ghq-github-com-mimikun-mimikun-problem-solving/memory/problem-awareness-growth.md`
 
 ## 🧠 Where memory goes (decide by scope AND by visibility)
 
@@ -189,7 +189,7 @@ published. Nothing personal goes in those.
 - **`~/.claude/projects/` is outside chezmoi, so project memory is not backed up.**
   Never leave knowledge you would mind losing in project memory alone.
 
-Recorded in `mimikun.kabeuti/records/P08-memory-bunsan.md`.
+Recorded in `mimikun.problem-solving/records/P08-memory-bunsan.md`.
 
 @RTK.md
 @private.md

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -132,7 +132,7 @@ Use **situation-first analysis (A-B-C) plus "How, not Why":**
 A 🔴 fixed in some other repo and never written down is a fix whose recurrence
 nobody will ever check. So when step 1 tags a problem 🔴, file a record:
 
-- Repo: `~/ghq/github.com/mimikun/mimikun.problem-solving/` — read its `handover.md`
+- Repo: `~/ghq/github.com/mimikun/mimikun.agent-system/` — read its `handover.md`
   first; it carries the rules that keep this from rotting.
 - Copy `records/_TEMPLATE.md` to `records/Pxx-<slug>.md`. List the directory
   first so `Pxx` does not collide.
@@ -162,7 +162,7 @@ nobody will ever check. So when step 1 tags a problem 🔴, file a record:
 - This conversational process trains **noticing** and **structuring** only.
 - Step 5's **execution** happens in the real world — reading me is not the same as doing it.
 
-Related memory: `projects/-home-mimikun-ghq-github-com-mimikun-mimikun-problem-solving/memory/problem-awareness-growth.md`
+Related memory: `projects/-home-mimikun-ghq-github-com-mimikun-mimikun-agent-system/memory/problem-awareness-growth.md`
 
 ## 🧠 Where memory goes (decide by scope AND by visibility)
 
@@ -203,7 +203,7 @@ published. Nothing personal goes in those.
 - **`~/.claude/projects/` is outside chezmoi, so project memory is not backed up.**
   Never leave knowledge you would mind losing in project memory alone.
 
-Recorded in `mimikun.problem-solving/records/P08-memory-bunsan.md`.
+Recorded in `mimikun.agent-system/records/P08-memory-bunsan.md`.
 
 @RTK.md
 @private.md

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -164,4 +164,32 @@ nobody will ever check. So when step 1 tags a problem 🔴, file a record:
 
 Related memory: `projects/-home-mimikun-ghq-github-com-mimikun-mimikun-kabeuti/memory/problem-awareness-growth.md`
 
+## 🧠 Where memory goes (decide by scope AND by visibility)
+
+Before writing a memory, answer two questions.
+
+1. **Scope** — is this knowledge needed in other directories, or only this one?
+2. **Visibility** — can it live in a public repo?
+
+| Scope | Public-safe | Destination |
+|---|---|---|
+| Every project | yes | `~/.claude/rules/<topic>.md` — chezmoi-managed, loaded everywhere |
+| Every project | no | `~/.claude/private.md` — symlink into the kabeuti repo, imported below |
+| This project only | — | project memory (the default location) |
+
+`~/.claude/` is chezmoi-managed, but its source repo `mimikun/dotfiles` is **public**.
+`CLAUDE.md`, `RTK.md`, `rules/**`, `settings.json`, `hooks/**` and `statusline.sh` are
+published. Nothing personal goes in those.
+
+**Two hard rules:**
+
+- **When cwd is under `/tmp`, do not write project memory.** That scope dies with the
+  directory and is never loaded again. Five memories were lost this way before 2026-07-26,
+  including the user's professional background. Put it in one of the two shared files instead.
+- **`~/.claude/projects/` is outside chezmoi, so project memory is not backed up.**
+  Never leave knowledge you would mind losing in project memory alone.
+
+Recorded in `mimikun.kabeuti/records/P08-memory-bunsan.md`.
+
 @RTK.md
+@private.md

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -174,8 +174,22 @@ Before writing a memory, answer two questions.
 | Scope | Public-safe | Destination |
 |---|---|---|
 | Every project | yes | `~/.claude/rules/<topic>.md` — chezmoi-managed, loaded everywhere |
-| Every project | no | `~/.claude/private.md` — symlink into the kabeuti repo, imported below |
-| This project only | — | project memory (the default location) |
+| Every project | no | `~/.claude/private.md` — symlink into the record repo, imported below |
+| This project only | yes | `PROJECT/CLAUDE.md` — travels with the repo's own git remote |
+| This project only | no | `~/.claude/private.md`, kept short |
+
+**Prefer `PROJECT/CLAUDE.md` over project memory.** Memory under
+`~/.claude/projects/<path>/memory/` belongs to no repo, syncs to no other machine, is
+invisible to anyone reading the project, and is orphaned the moment the directory is
+renamed — nine memories had to be moved by hand on 2026-07-26 for exactly that reason.
+`PROJECT/CLAUDE.md` has none of those properties. Write project memory only when the repo
+has no CLAUDE.md and creating one would be intrusive.
+
+**Check the repo's visibility before writing to `PROJECT/CLAUDE.md`** — `~/.config/nvim`,
+`~/.config/fish`, `~/.local/share/chezmoi` and several `mimikun.*` repos are public. Health,
+employment, finances, or anything about the user's situation never goes into a public repo,
+whatever its scope; put it in `~/.claude/private.md`. Inside a private repo those subjects
+are fine, and belong in that repo's own `CLAUDE.md` rather than in the global file.
 
 `~/.claude/` is chezmoi-managed, but its source repo `mimikun/dotfiles` is **public**.
 `CLAUDE.md`, `RTK.md`, `rules/**`, `settings.json`, `hooks/**` and `statusline.sh` are

--- a/dot_claude/hooks/executable_check-settings-env.sh
+++ b/dot_claude/hooks/executable_check-settings-env.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SessionStart hook: verify that the env vars declared in settings.json actually
+# exist in the installed Claude Code binary.
+#
+# The "env" block in settings.json is a free-form passthrough: Claude Code never
+# validates the names, and emits no warning for one it does not read. An invented
+# or misspelled variable therefore stays silently inert forever. Asking the binary
+# directly is the only check that does not depend on documentation.
+set -uo pipefail
+
+settings="$HOME/.claude/settings.json"
+cache="$HOME/.claude/.settings-env-check"
+
+[ -r "$settings" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+binary=${CLAUDE_CODE_EXECPATH:-$(command -v claude 2>/dev/null)}
+binary=$(readlink -f "$binary" 2>/dev/null) || exit 0
+[ -f "$binary" ] || exit 0
+
+keys=$(jq -r '(.env // {}) | keys[]' "$settings" 2>/dev/null) || exit 0
+[ -n "$keys" ] || exit 0
+
+# The binary is ~275MB, so re-scan only when the binary or the declared key set
+# changes. That is exactly when the answer can change: an upgrade, or an edit.
+stamp=$(printf '%s\n%s\n%s' "$binary" "$(stat -c %s "$binary" 2>/dev/null)" "$keys" |
+  md5sum | cut -d' ' -f1)
+
+if [ -r "$cache" ] && [ "$(head -n1 "$cache")" = "$stamp" ]; then
+  missing=$(tail -n +2 "$cache")
+else
+  missing=""
+  while IFS= read -r k; do
+    [ -n "$k" ] || continue
+    grep -qaF -- "$k" "$binary" || missing+="$k"$'\n'
+  done <<<"$keys"
+  printf '%s\n%s' "$stamp" "$missing" >"$cache"
+fi
+
+missing=$(printf '%s' "$missing" | sed '/^$/d')
+[ -n "$missing" ] || exit 0
+
+read -r -d '' msg <<EOF || true
+SETTINGS ENV CHECK — these keys in the "env" block of ~/.claude/settings.json are
+not referenced anywhere in the running Claude Code binary ($binary), so they have
+no effect on Claude Code itself:
+
+$missing
+
+Report this to the user in Japanese at the very start of your first reply, listing
+the key names. A variable intended purely as a passthrough to hooks or MCP servers
+is expected to show up here and is not a defect — say so rather than calling it a
+mistake outright.
+EOF
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+  "$(jq -Rs . <<<"$msg")"
+exit 0

--- a/dot_claude/hooks/executable_herdr-agent-state.sh
+++ b/dot_claude/hooks/executable_herdr-agent-state.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=claude
+# HERDR_INTEGRATION_VERSION=7
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-claude-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:claude"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+is_subagent = bool(hook_input.get("agent_id"))
+if is_subagent:
+    raise SystemExit(0)
+if hook_event_name == "SubagentStop":
+    # SubagentStop is a completion event. Older Herdr integrations mapped it
+    # to durable working, but Claude recap/away-summary can emit it after the
+    # main turn has already stopped. Never let it revive an idle pane.
+    raise SystemExit(0)
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+transcript_path = hook_input.get("transcript_path")
+agent_session_path = transcript_path if isinstance(transcript_path, str) and transcript_path else None
+session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+if not isinstance(session_start_source, str) or not session_start_source:
+    session_start_source = None
+if agent_session_id:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "claude",
+        "seq": report_seq,
+        "agent_session_id": agent_session_id,
+    }
+    if agent_session_path:
+        params["agent_session_path"] = agent_session_path
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -6,7 +6,7 @@
     "obsidian@obsidian-skills": true
   },
   "env": {
-    "CLAUDE_CODE_HIDE_ACCOUNT_INFO": "1"
+    "IS_DEMO": "1"
   },
   "extraKnownMarketplaces": {
     "dotnet-agent-skills": {
@@ -70,6 +70,16 @@
       }
     ],
     "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bash '/home/mimikun/.claude/hooks/check-settings-env.sh'",
+            "timeout": 20,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      },
       {
         "hooks": [
           {

--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -43,6 +43,6 @@ files that load only when matching files are touched.
   free-form passthrough, so Claude Code cannot warn about a name it does not read, and a
   wrong one stays silently inert forever. This actually happened —
   `CLAUDE_CODE_HIDE_ACCOUNT_INFO` was set for months and never existed
-  (filed as P07 in `mimikun.problem-solving`; the working flag is `IS_DEMO`).
+  (filed as P07 in `mimikun.agent-system`; the working flag is `IS_DEMO`).
 - `~/.claude/hooks/check-settings-env.sh` re-runs that check at session start, but it only
   sees settings.json. Naming a setting in conversation is not covered — grep first.

--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -43,6 +43,6 @@ files that load only when matching files are touched.
   free-form passthrough, so Claude Code cannot warn about a name it does not read, and a
   wrong one stays silently inert forever. This actually happened —
   `CLAUDE_CODE_HIDE_ACCOUNT_INFO` was set for months and never existed
-  (filed as P07 in `mimikun.kabeuti`; the working flag is `IS_DEMO`).
+  (filed as P07 in `mimikun.problem-solving`; the working flag is `IS_DEMO`).
 - `~/.claude/hooks/check-settings-env.sh` re-runs that check at session start, but it only
   sees settings.json. Naming a setting in conversation is not covered — grep first.

--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -30,3 +30,19 @@ files that load only when matching files are touched.
 - **Commits:** Conventional Commits — `feat(scope): subject`, `fix`, `docs`,
   `perf`, `refactor`.
 - **PRs:** focus on problem & solution; no co-authored-by / tool mentions.
+
+## 🤖 Claude Code's own configuration
+
+- The live config is `~/.claude/settings.json`, and it is chezmoi-managed
+  (`dot_claude/private_settings.json`). Editing the file directly creates drift —
+  run `chezmoi add` afterwards, or use `chezmoi edit`. **Do not judge whether something is
+  backed up by whether it is a git repo.**
+- `~/ghq/github.com/mimikun/mimikun.claude-code-config/` is abandoned. Do not read or edit it.
+- **Verify every setting key and env var against the binary before recommending it:**
+  `grep -c '<name>' (readlink -f (which claude))`. The `env` block of settings.json is a
+  free-form passthrough, so Claude Code cannot warn about a name it does not read, and a
+  wrong one stays silently inert forever. This actually happened —
+  `CLAUDE_CODE_HIDE_ACCOUNT_INFO` was set for months and never existed
+  (filed as P07 in `mimikun.kabeuti`; the working flag is `IS_DEMO`).
+- `~/.claude/hooks/check-settings-env.sh` re-runs that check at session start, but it only
+  sees settings.json. Naming a setting in conversation is not covered — grep first.


### PR DESCRIPTION

The "env" block of settings.json is a free-form passthrough, so Claude Code
cannot warn about a variable it never reads. CLAUDE_CODE_HIDE_ACCOUNT_INFO sat
there inert for months: the name appears in none of the installed binaries.

This SessionStart hook greps the running binary for every declared key and
reports the ones with no reference, re-scanning only when the binary or the key
set changes (45ms warm, 178ms on a full scan).

Hooks join the allowlist at the same time. settings.json references them by
absolute path, so leaving them unmanaged made a fresh apply produce a config
whose SessionStart hooks point at files that do not exist.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jj8CsazG3HErSSnmwVHifV