### PR TITLE
Move inline Claude Code hooks into scripts, and manage agent skills

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -13,6 +13,13 @@
 # settings.json whose SessionStart hooks point at files that do not exist.
 !.claude/hooks
 !.claude/hooks/**
+# Skills are normally reinstallable and therefore left unmanaged (see
+# .chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl).
+# use-spark is the exception: it has no upstream repo and no CLI that ships
+# it, so this copy is the only one that exists.
+!.claude/skills
+!.claude/skills/use-spark
+!.claude/skills/use-spark/**
 
 # HACK: Now configuration... 2026年3月17日
 .config/elvish/**

--- a/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
@@ -1,0 +1,69 @@
+{{ if (eq .chezmoi.os "linux") -}}
+
+#!/bin/bash
+
+# Reinstall the global agent skills used by Claude Code and Codex CLI.
+#
+# The skills themselves are NOT stored in this repository. Each one is either
+# published in a remote repo (installed with `npx skills`) or bundled inside
+# its own CLI (installed with that CLI's own subcommand). Committing the
+# generated SKILL.md files here would create a second copy to sync by hand.
+#
+# The one exception is use-spark: no upstream repo, and the spark CLI has no
+# subcommand that ships it, so its SKILL.md is tracked under
+# dot_claude/skills/use-spark/ and restored by chezmoi itself.
+#
+# No `set -e`: one unreachable network or missing CLI must not abort the rest.
+
+skills_dir="$HOME/.agents/skills"
+agents="claude,codex"
+
+# --- skills published in a remote repo --------------------------------------
+declare -A remote_skills=(
+    ["browser-use"]="browser-use/browser-use"
+    ["find-skills"]="vercel-labs/skills"
+    ["herdr"]="ogulcancelik/herdr"
+)
+
+for name in "${!remote_skills[@]}"; do
+    if [[ -d "$skills_dir/$name" ]]; then
+        echo "skill '$name' is already installed."
+    else
+        echo "Installing skill '$name' from ${remote_skills[$name]}"
+        npx -y skills add "${remote_skills[$name]}" \
+            --global --agent "$agents" --skill "$name" --yes
+    fi
+done
+
+# --- skills bundled inside their own CLI ------------------------------------
+# `officecli install` would also register an MCP server, which is not wanted
+# here; `officecli skills install` places the SKILL.md only.
+if [[ -d "$skills_dir/neowright" ]]; then
+    echo "skill 'neowright' is already installed."
+elif command -v neowright >/dev/null 2>&1; then
+    neowright skills install --global
+fi
+
+if [[ -d "$skills_dir/officecli" ]]; then
+    echo "skill 'officecli' is already installed."
+elif command -v officecli >/dev/null 2>&1; then
+    officecli skills install claude
+fi
+
+# --- CLIs the skills drive --------------------------------------------------
+# A skill whose CLI is missing looks installed but fails on its first command,
+# so report the gap rather than leaving it silent.
+check_cli() {
+    command -v "$1" >/dev/null 2>&1 \
+        || echo "WARN: '$1' is missing, so skill '$2' will not work. See $3"
+}
+
+check_cli browser-use browser-use "https://github.com/browser-use/browser-use"
+check_cli herdr       herdr       "https://github.com/ogulcancelik/herdr"
+check_cli neowright   neowright   "https://github.com/isak102/neowright"
+check_cli officecli   officecli   "https://github.com/iOfficeAI/OfficeCLI"
+check_cli spark       use-spark   "ships with Spark Desktop, which must be running"
+
+# vim:ft=bash.chezmoitmpl
+
+{{ end -}}

--- a/docs/plan/hooks-to-scripts-20260731.md
+++ b/docs/plan/hooks-to-scripts-20260731.md
@@ -1,0 +1,106 @@
+# インライン hook を bash スクリプトへ切り出す計画 (2026-07-31)
+
+`dot_claude/private_settings.json` に JSON 文字列として直接埋まっている hook を、
+`dot_claude/hooks/` 配下の bash スクリプトへ移す。settings.json 側はスクリプトを
+呼ぶだけにする。
+
+方針の出典は `claude-permission-holes-20260731.md` の末尾「将来の方針」。
+外部ツール (cchook 等) は採用しない。
+
+## 着手前の棚卸し (2026-07-31 実測)
+
+hook は全10本。**切り出す対象は5本**で、残り5本は既に外部コマンドか
+スクリプト呼び出しなので手を入れない。
+
+| 種別 | 本数 | 中身 | 対象 |
+|---|---|---|---|
+| インライン shell (Bash ガード) | 4 | `destructive push` / `recursive rm` / `destructive git` / `interpreter one-liners`。356〜739文字 | ✅ |
+| インライン shell (Todoist) | 1 | matcher は `mcp__claude_ai_Todoist__(add\|update\|...)-`。440文字 | ✅ |
+| 外部コマンド | 3 | `git-ai checkpoint` ×2、`rtk hook claude` | — |
+| 既存スクリプト呼び出し | 2 | SessionStart の `check-settings-env.sh` / `herdr-agent-state.sh` | — |
+
+`claude-permission-holes-20260731.md` は「hook 4本」と書いているが、
+インラインは実際には5本ある。
+
+### 中身を読んで分かったこと
+
+- **Todoist hook はガードではない。** 正規表現も deny も無く、静的な
+  `additionalContext` を `echo` しているだけ (Todoist 同期ルールの注入)。
+  113ケースのテストが当たっていないのは穴ではなく、**判定する分岐が無い**から。
+  スクリプト化の利点は安全性ではなく、JSON の中の JSON という二重エスケープが
+  解けて文章として読めるようになること
+- **Bash ガード4本は同一の形**: `jq -r '.tool_input.command'` → `grep -Eq <正規表現>`
+  → deny JSON を `printf` → 末尾 `|| true`。one-liners だけ grep 2段
+  (インタプリタ判定 + 危険API判定)
+- **`.chezmoiignore.tmpl` は対応不要。** 既に `!.claude/hooks/**` がある
+
+## ⚠️ 最大の事故ポイント: `set -euo pipefail` と終了コード
+
+`grep -Eq` が**マッチしない**ことは正常系であり、終了コードは1になる。現行の
+インライン版は末尾 `|| true` でこれを0に潰している。hook は非ゼロ終了だと
+Claude Code 側の扱いが変わるため、**`set -euo pipefail` を付けたスクリプトへ
+機械的に移すと、マッチしなかった全ケースで hook が異常終了する。**
+
+各スクリプトは次を明示的に満たすこと:
+
+- マッチした → deny JSON を stdout に出して **exit 0**
+- マッチしない → 何も出さず **exit 0**
+
+## 決定事項
+
+| # | 論点 | 決定 |
+|---|---|---|
+| D1 | 切り出す範囲 | インライン5本すべて。JSON にインライン shell を一行も残さない |
+| D2 | スクリプトの粒度 | 1 hook = 1スクリプト。**共通 lib は作らない** — hook が壊れると全作業が止まるので、共通失敗点を作らず独立性を優先する |
+| D3 | テストランナー | スクリプトを直接呼ぶ。**加えて settings.json からの参照検査を追加する** |
+| D4 | 進め方 | 1本ずつ切り出し、都度113ケースを実行して1ステップ1コミット |
+
+### D3 の参照検査を入れる理由
+
+case ファイルが指すスクリプトが `hooks.PreToolUse` から実際に参照されているかを
+検査する。これが無いと、パスを typo した状態で**スクリプト単体テストは全緑なのに
+本番の hook は一本も動いていない**という状態を見逃す。
+
+同日の permission 監査で「設定同士の整合性は発火の証拠にならない」を一度踏んで
+いる。同じ形の罠を先に塞ぐ。
+
+### 移行中もテストを緑に保つ仕掛け
+
+D4 (1本ずつ) と D3 (スクリプト直接実行) を両立させるため、ランナーに**一時的な
+二重解決**を入れる。case ファイルの `# hook:` が指すスクリプトが存在すれば
+それを実行し、無ければ従来どおり `statusMessage` で settings.json から引く。
+
+これで「移行済み1本 + 未移行3本」の途中状態でも全ケースが走る。手順7で
+fallback を削除する。
+
+## 手順 (1コミット = 1ステップ)
+
+ベースライン: 着手前に113ケース全緑を確認済み。
+
+| # | 内容 | 検証 |
+|---|---|---|
+| 1 | ランナーに二重解決 + 参照検査を追加 | 113緑 (まだ何も移行していない) |
+| 2 | `deny-recursive-rm.sh` を切り出し | 31ケースがスクリプト経由で緑 |
+| 3 | `deny-destructive-push.sh` | 30ケース |
+| 4 | `deny-destructive-git.sh` | 24ケース |
+| 5 | `deny-interpreter-oneliners.sh` | 28ケース。**grep 2段で最難関** |
+| 6 | `todoist-sync-reminder.sh` | ケース無し。手で叩いて JSON 妥当性を確認 |
+| 7 | ランナーから fallback を削除 | 113緑、全件スクリプト経由 |
+| 8 | 実機確認 (再起動して各ガードを踏む) | — |
+
+配置は既存に倣い `dot_claude/hooks/executable_<name>.sh`
+(実体は `~/.claude/hooks/<name>.sh`)。
+
+### 手順8で踏む材料
+
+2026-07-31 のセッション中に `rm -rf node_modules` と `git push --delete` が
+どちらもブロックされた。つまり recursive-rm と destructive-push は移行前の
+時点で確実に生きている。移行後に同じ2つを踏み直せば、この2本は挙動が
+変わっていないと言い切れる。
+
+## やらないこと
+
+- 正規表現そのものの変更。**移行と挙動変更を同じコミットに混ぜない。**
+  正規表現は3回書き直して3回とも穴が見つかっている
+- `scripts/test-claude-hooks.sh` の削除・縮小
+- 外部コマンド3本と SessionStart スクリプト2本への変更

--- a/dot_claude/hooks/executable_check-agent-skills.sh
+++ b/dot_claude/hooks/executable_check-agent-skills.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SessionStart hook: notice when an agent skill has fallen behind the CLI that
+# ships it.
+#
+# Only skills bundled inside their own CLI are checked. Those are the ones that
+# go stale silently: the CLI upgrades on its own schedule while the SKILL.md
+# left on disk never changes, and the installer in
+# .chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl skips
+# any skill that is already present. Skills installed from a remote repo are
+# not checked, because asking upstream needs the network and a SessionStart
+# hook has to stay offline and fast.
+#
+# Notify only, never reinstall: `<cli> skills install` overwrites a file that
+# chezmoi may be tracking, so that call belongs to the user.
+set -uo pipefail
+
+notices=""
+
+# --- use-spark ---------------------------------------------------------------
+# The only skill carrying a version in its front matter, so it gets a real
+# comparison instead of the mtime heuristic below. It is also the only one
+# chezmoi tracks, hence the extra `chezmoi add` in the suggested command.
+spark_skill="$HOME/.claude/skills/use-spark/SKILL.md"
+if command -v spark >/dev/null 2>&1 && [ -r "$spark_skill" ]; then
+  # Read the version out of the front matter only: "version:" also appears in
+  # the body, and the first body match would win.
+  have=$(sed -n '2,/^---[[:space:]]*$/p' "$spark_skill" |
+    sed -n 's/^[[:space:]]*version:[[:space:]]*//p' | head -n1 | tr -d '[:space:]')
+  # Spark Desktop may be down; --version must not stall the session start.
+  want=$(timeout 5 spark --version 2>/dev/null | head -n1 | tr -d '[:space:]')
+  if [ -n "$have" ] && [ -n "$want" ] && [ "$have" != "$want" ] &&
+    [ "$(printf '%s\n%s\n' "$have" "$want" | sort -V | tail -n1)" = "$want" ]; then
+    notices+="- use-spark: skill is $have, spark CLI is $want."
+    notices+=" Refresh: spark skill > '$spark_skill' && chezmoi add '$spark_skill'"$'\n'
+  fi
+fi
+
+# --- skills with no version in their front matter -----------------------------
+# Fall back to mtime: a CLI binary newer than the SKILL.md it shipped means the
+# file on disk predates the running CLI. Reinstalling rewrites SKILL.md, so the
+# notice clears itself and needs no cache or state file.
+check_mtime() {
+  local cli=$1 name=$2 reinstall=$3 skill bin
+  skill="$HOME/.agents/skills/$name/SKILL.md"
+  command -v "$cli" >/dev/null 2>&1 || return 0
+  [ -r "$skill" ] || return 0
+  bin=$(readlink -f "$(command -v "$cli")" 2>/dev/null) || return 0
+  [ -n "$bin" ] && [ "$bin" -nt "$skill" ] || return 0
+  notices+="- $name: the $cli binary is newer than its SKILL.md, so the skill may predate it."
+  notices+=" Refresh: $reinstall"$'\n'
+}
+
+check_mtime neowright neowright "neowright skills install --global"
+check_mtime officecli officecli "officecli skills install claude"
+
+[ -n "$notices" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+read -r -d '' msg <<EOF || true
+AGENT SKILL CHECK — these skills look older than the CLI that ships them:
+
+$notices
+Report this to the user in Japanese at the very start of your first reply, and
+offer to run the refresh command. This is a heuristic, not proof: for entries
+detected by mtime, a CLI reinstall alone can trip it without the skill actually
+having changed. Do not refresh anything unless the user asks.
+EOF
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' \
+  "$(jq -Rs . <<<"$msg")"
+exit 0

--- a/dot_claude/hooks/executable_deny-destructive-git.sh
+++ b/dot_claude/hooks/executable_deny-destructive-git.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny git clean --force and git reset --hard.
+#
+# Both discard uncommitted work with no undo. permissions.deny only matches the
+# head of a command, so it cannot see a flag placed after the pathspec, a
+# bundled short flag, or a git reached through a pipeline.
+#
+# Contract: print the deny payload and exit 0 when the command matches, print
+# nothing and exit 0 otherwise. Never exit non-zero — a failing hook aborts
+# commands it was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/destructive-git.txt
+
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command // empty')
+
+pattern='git[[:space:]]+(clean([[:space:]][^;&|]*)?[[:space:]]+(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)|reset([[:space:]][^;&|]*)?[[:space:]]+--hard([[:space:]]|$))'
+
+if printf '%s' "$command" | grep -Eq "$pattern"; then
+    printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"git clean --force and git reset --hard are blocked. Run it by hand if you really need it."}}'
+fi

--- a/dot_claude/hooks/executable_deny-destructive-git.sh
+++ b/dot_claude/hooks/executable_deny-destructive-git.sh
@@ -13,7 +13,9 @@
 
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command // empty')
+# Input that jq cannot parse must not abort the hook. The inline version had no
+# set -e and simply carried on with an empty command, so match that.
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
 
 pattern='git[[:space:]]+(clean([[:space:]][^;&|]*)?[[:space:]]+(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)|reset([[:space:]][^;&|]*)?[[:space:]]+--hard([[:space:]]|$))'
 

--- a/dot_claude/hooks/executable_deny-destructive-push.sh
+++ b/dot_claude/hooks/executable_deny-destructive-push.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny destructive git push.
+#
+# Covers force, mirror, delete and `+refspec` pushes. permissions.deny only
+# matches the head of a command, so it cannot see a flag placed after the
+# remote, a short form, or a push reached through a pipeline.
+#
+# Contract: print the deny payload and exit 0 when the command matches, print
+# nothing and exit 0 otherwise. Never exit non-zero — a failing hook aborts
+# commands it was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/destructive-push.txt
+
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command // empty')
+
+pattern='git[[:space:]]+push([[:space:]][^;&|]*)?[[:space:]]+(["]?\+[^[:space:]]|(--force[^[:space:]]*|--mirror|--delete|-f|-d)([[:space:]]|$))'
+
+if printf '%s' "$command" | grep -Eq "$pattern"; then
+    printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Destructive push is blocked (force, mirror, delete, or a + refspec). Run it by hand if you really need it."}}'
+fi

--- a/dot_claude/hooks/executable_deny-destructive-push.sh
+++ b/dot_claude/hooks/executable_deny-destructive-push.sh
@@ -13,7 +13,9 @@
 
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command // empty')
+# Input that jq cannot parse must not abort the hook. The inline version had no
+# set -e and simply carried on with an empty command, so match that.
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
 
 pattern='git[[:space:]]+push([[:space:]][^;&|]*)?[[:space:]]+(["]?\+[^[:space:]]|(--force[^[:space:]]*|--mirror|--delete|-f|-d)([[:space:]]|$))'
 

--- a/dot_claude/hooks/executable_deny-interpreter-oneliners.sh
+++ b/dot_claude/hooks/executable_deny-interpreter-oneliners.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny interpreter one-liners that remove
+# files or spawn processes.
+#
+# `python -c`, `node -e`, `perl -e` and friends are a way around every guard
+# that reads the shell command, because the destructive part lives inside a
+# string the shell never interprets.
+#
+# Two conditions, and both must hold. Matching only the interpreter would block
+# every legitimate one-liner; matching only the API names would block any
+# command that merely mentions them, `grep subprocess` included.
+#
+#   1. an interpreter invoked with -c / -e / -p / --eval / eval
+#   2. a call that removes files or spawns a process
+#
+# Contract: print the deny payload and exit 0 when both match, print nothing
+# and exit 0 otherwise. Never exit non-zero — a failing hook aborts commands it
+# was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/interpreter-oneliners.txt
+
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command // empty')
+
+interpreter='(^|[[:space:];&|(/])(python[0-9.]*|node|deno|bun|perl|ruby)[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[cep]([[:space:]]|$)|--eval([[:space:]]|=)|eval([[:space:]]|$))'
+dangerous_call='(rmtree|shutil|subprocess|child_process|execSync|spawnSync|os\.system|os\.popen|os\.remove|os\.rmdir|unlink|rmSync|rmdirSync|Deno\.remove|Deno\.run|Deno\.Command|FileUtils|File\.delete|Dir\.delete|\.rmdir|truncate)'
+
+if printf '%s' "$command" | grep -Eq "$interpreter" &&
+    printf '%s' "$command" | grep -Eq "$dangerous_call"; then
+    printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Interpreter one-liner touching file removal or process spawning is blocked. Write a script file, or run it by hand."}}'
+fi

--- a/dot_claude/hooks/executable_deny-interpreter-oneliners.sh
+++ b/dot_claude/hooks/executable_deny-interpreter-oneliners.sh
@@ -21,7 +21,9 @@
 
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command // empty')
+# Input that jq cannot parse must not abort the hook. The inline version had no
+# set -e and simply carried on with an empty command, so match that.
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
 
 interpreter='(^|[[:space:];&|(/])(python[0-9.]*|node|deno|bun|perl|ruby)[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[cep]([[:space:]]|$)|--eval([[:space:]]|=)|eval([[:space:]]|$))'
 dangerous_call='(rmtree|shutil|subprocess|child_process|execSync|spawnSync|os\.system|os\.popen|os\.remove|os\.rmdir|unlink|rmSync|rmdirSync|Deno\.remove|Deno\.run|Deno\.Command|FileUtils|File\.delete|Dir\.delete|\.rmdir|truncate)'

--- a/dot_claude/hooks/executable_deny-recursive-rm.sh
+++ b/dot_claude/hooks/executable_deny-recursive-rm.sh
@@ -13,7 +13,9 @@
 
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command // empty')
+# Input that jq cannot parse must not abort the hook. The inline version had no
+# set -e and simply carried on with an empty command, so match that.
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
 
 pattern='(^|[[:space:];&|(/])rm[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)'
 

--- a/dot_claude/hooks/executable_deny-recursive-rm.sh
+++ b/dot_claude/hooks/executable_deny-recursive-rm.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny recursive rm.
+#
+# permissions.deny only matches the head of a command, so it cannot see a flag
+# placed after the operand, a bundled short flag, or an rm reached through a
+# pipeline. This hook carries those cases.
+#
+# Contract: print the deny payload and exit 0 when the command matches, print
+# nothing and exit 0 otherwise. Never exit non-zero — a failing hook aborts
+# commands it was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/recursive-rm.txt
+
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command // empty')
+
+pattern='(^|[[:space:];&|(/])rm[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)'
+
+if printf '%s' "$command" | grep -Eq "$pattern"; then
+    printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Recursive rm is blocked. Run it by hand if you really need it."}}'
+fi

--- a/dot_claude/hooks/executable_todoist-sync-reminder.sh
+++ b/dot_claude/hooks/executable_todoist-sync-reminder.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: the Todoist write tools) — inject the sync rule.
+#
+# Not a guard. It reads no input, decides nothing, and never denies; it prints
+# additionalContext so the rule is in front of the model at call time rather
+# than only in CLAUDE.md, which may have scrolled far out of attention.
+#
+# The rule exists because the user also edits Todoist from the desktop and
+# mobile apps, so any listing fetched earlier in the session can be stale by
+# the time a write goes out.
+#
+# There is nothing here to regression-test, which is why the suite has no cases
+# for it. Changing the text is safe; producing invalid JSON is not, so the
+# payload is built with jq rather than written out by hand.
+
+set -euo pipefail
+
+read -r -d '' context <<'EOF' || true
+TODOIST SYNC RULE: the user also edits Todoist from desktop and mobile apps, so any listing fetched earlier in this session may already be stale. (1) BEFORE this write, re-fetch the target with find-tasks / get-overview unless you already did so in this same turn. (2) AFTER the write, re-fetch the same query and verify by count before claiming completion.
+EOF
+
+jq -cn --arg c "$context" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $c}}'

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -78,7 +78,7 @@
       {
         "hooks": [
           {
-            "command": "jq -r '.tool_input.command // empty' | grep -Eq 'git[[:space:]]+push([[:space:]][^;&|]*)?[[:space:]]+([\"]?\\+[^[:space:]]|(--force[^[:space:]]*|--mirror|--delete|-f|-d)([[:space:]]|$))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Destructive push is blocked (force, mirror, delete, or a + refspec). Run it by hand if you really need it.\"}}' || true",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-push.sh'",
             "statusMessage": "Checking for destructive push",
             "type": "command"
           }

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -69,7 +69,7 @@
       {
         "hooks": [
           {
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"TODOIST SYNC RULE: the user also edits Todoist from desktop and mobile apps, so any listing fetched earlier in this session may already be stale. (1) BEFORE this write, re-fetch the target with find-tasks / get-overview unless you already did so in this same turn. (2) AFTER the write, re-fetch the same query and verify by count before claiming completion.\"}}'",
+            "command": "bash '/home/mimikun/.claude/hooks/todoist-sync-reminder.sh'",
             "type": "command"
           }
         ],

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -88,7 +88,7 @@
       {
         "hooks": [
           {
-            "command": "jq -r '.tool_input.command // empty' | grep -Eq '(^|[[:space:];&|(/])rm[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)([[:space:]]|$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Recursive rm is blocked. Run it by hand if you really need it.\"}}' || true",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-recursive-rm.sh'",
             "statusMessage": "Checking for recursive rm",
             "type": "command"
           }
@@ -383,10 +383,6 @@
     ]
   },
   "skillOverrides": {
-    "browser-use": "off",
-    "find-skills": "off",
-    "hello-skill": "off",
-    "nippo": "off",
     "officecli": "off"
   },
   "statusLine": {

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -136,6 +136,16 @@
           }
         ],
         "matcher": "*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "bash '/home/mimikun/.claude/hooks/check-agent-skills.sh'",
+            "timeout": 15,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
       }
     ]
   },

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -98,7 +98,7 @@
       {
         "hooks": [
           {
-            "command": "jq -r '.tool_input.command // empty' | grep -Eq 'git[[:space:]]+(clean([[:space:]][^;&|]*)?[[:space:]]+(-[a-zA-Z]*f[a-zA-Z]*|--force)([[:space:]]|$)|reset([[:space:]][^;&|]*)?[[:space:]]+--hard([[:space:]]|$))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"git clean --force and git reset --hard are blocked. Run it by hand if you really need it.\"}}' || true",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-git.sh'",
             "statusMessage": "Checking for destructive git",
             "type": "command"
           }

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -108,7 +108,7 @@
       {
         "hooks": [
           {
-            "command": "c=$(jq -r '.tool_input.command // empty'); printf '%s' \"$c\" | grep -Eq '(^|[[:space:];&|(/])(python[0-9.]*|node|deno|bun|perl|ruby)[[:space:]]+([^;&|]*[[:space:]])?(-[a-zA-Z]*[cep]([[:space:]]|$)|--eval([[:space:]]|=)|eval([[:space:]]|$))' && printf '%s' \"$c\" | grep -Eq '(rmtree|shutil|subprocess|child_process|execSync|spawnSync|os\\.system|os\\.popen|os\\.remove|os\\.rmdir|unlink|rmSync|rmdirSync|Deno\\.remove|Deno\\.run|Deno\\.Command|FileUtils|File\\.delete|Dir\\.delete|\\.rmdir|truncate)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Interpreter one-liner touching file removal or process spawning is blocked. Write a script file, or run it by hand.\"}}' || true",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-interpreter-oneliners.sh'",
             "statusMessage": "Checking interpreter one-liners",
             "type": "command"
           }

--- a/dot_claude/skills/use-spark/SKILL.md
+++ b/dot_claude/skills/use-spark/SKILL.md
@@ -1,0 +1,780 @@
+---
+name: use-spark
+description: >-
+  Use the spark CLI to access the user's Spark email data - list emails,
+  search by topic, read threads, check calendar events, find availability,
+  look up contacts, and view team info. Use when the user asks about their
+  emails, calendar, contacts, meetings, or scheduling.
+metadata:
+  version: 1.3.0
+  requires:
+    bins:
+      - spark
+---
+
+# Using spark
+
+`spark` is a CLI for the Spark email client. Use it to query the user's mailbox, calendar, contacts, meetings, and team data.
+
+## Running spark
+
+```bash
+spark <command> [options]
+```
+
+**Environment:** `spark` is a thin client that talks over IPC to the user's running Spark Desktop app - it does not ship its own mailbox, network stack, or credentials. Run it directly on the user's computer against the live Spark Desktop process. Do not try to execute it inside a sandbox, container, CI runner, or any environment isolated from the user's desktop session - it will fail to connect. If Spark Desktop is not running, ask the user to launch it instead of retrying.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `accounts` | List accounts, calendars, teams, shared inboxes, and access levels |
+| `folders` | List folders/labels with message counts |
+| `emails` | List emails with filters and pagination |
+| `search` | Hybrid keyword + semantic search with full bodies |
+| `thread` | Read full thread - headers, bodies, attachments |
+| `attachment` | Read a single email attachment by its ID (auto-downloads) |
+| `draft` | Create or edit an email draft (new, reply, forward, from template) |
+| `templates` | List saved message templates (personal and team) |
+| `template` | Show a single template by ID or name with its placeholders |
+| `comment` | Post a team comment on a thread |
+| `events` | List calendar events for a time range |
+| `event` | Create, update, delete, or RSVP to a calendar event, including managing attendees / invitations |
+| `availability` | Find free time slots, optionally with attendees |
+| `contacts` | Search contacts by name or email |
+| `team` | Show team info, members, shared inboxes, assignments |
+| `meetings` | List meeting transcripts |
+| `meeting` | Read a single meeting transcript |
+| `action` | Perform actions on emails (archive, pin, snooze, assign, etc.) |
+| `contact-action` | Perform actions on contacts (block, accept, categorize, etc.) |
+
+### accounts
+
+List all configured accounts with their calendars, teams, and shared inboxes. Each account and shared inbox shows its **access level** in parentheses, which controls what operations Spark can perform.
+
+```bash
+spark accounts
+```
+
+Run this first to discover what accounts, calendars, and teams are available, and to check their access levels.
+
+**Access levels:**
+
+| Level | Allowed operations |
+|-------|-------------------|
+| **read-only** | List, search, and read emails, threads, folders, events, contacts, meetings, teams |
+| **triage** | Everything in read-only plus all write operations: drafts, team comments, email actions (archive, move, pin, snooze, assign, etc.), contact actions (block, accept, categorize, etc.) |
+| **send** | Everything in triage plus mail-emitting operations: sending drafts (`action send`, including scheduled "Send Later"), and the entire `event` command: `event create` / `event update` / `event delete` / `event rsvp`, including attaching or detaching attendees via `--add` / `--remove` and the iTIP REQUEST / UPDATE / CANCEL / REPLY mail that goes with them. |
+
+Access levels are configured separately for each account and each shared inbox in Spark Desktop under Settings -> AI Agents. Shared inboxes can have a different access level than the parent account - for example, a personal account may have triage access while a shared inbox under the same team is read-only or disabled.
+
+If a command requires a higher access level than the account or shared inbox has, it returns an error with instructions on how to change the level.
+
+### folders
+
+List folders with message counts. Output includes folder identifiers in parentheses - use these as arguments to `emails` and `search`. Mailboxes backed by a Google account show `(Gmail labels)` on the **Email Account** or **Shared Inbox** header. Teams show the team name as a usable identifier for `emails`.
+
+```bash
+spark folders                        # all accounts
+spark folders user@example.com       # single account
+```
+
+### emails
+
+List emails with metadata (ID, From, Date, Subject, Flags). Supports pagination and Gmail-style filters.
+
+```bash
+spark emails                                                   # Unified Inbox
+spark emails user@example.com:Archive                          # specific folder
+spark emails "My Team"                                         # all shared threads in a team
+spark emails --filter "from:alice@co.com is:unread"             # filtered
+spark emails --filter "newer_than:7d has:attachment"            # recent with attachments
+spark emails --page 2 --page-size 20                           # pagination
+spark emails --order ascending                                 # oldest first
+spark emails --new-senders                                     # show only new sender emails
+```
+
+**GateKeeper filtering:** When viewing the Inbox with GateKeeper in explicit mode, new sender emails are automatically filtered out and a "New Senders" count is shown at the top. Use `--new-senders` to view those emails. Use `contact-action acceptContact <email>` or `contact-action blockContact <email>` to accept or block a sender.
+
+**Folder identifier formats** (run `folders` to see available ones):
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| Bare name | `Inbox`, `Archive` | Unified folder (cross-account) |
+| `email` | `user@example.com` | Account inbox shorthand |
+| `email:Folder` | `user@example.com:Archive` | Specific account folder |
+| `"Team Name"` | `"My Team"` | All shared threads in a team (quote if spaces) |
+| `shared@email:Folder` | `shared@co.com:Inbox` | Shared inbox folder |
+
+**Filter operators** (combinable, Gmail-style):
+
+| Operator | Example |
+|----------|---------|
+| `from:<addr>` | `from:alice@co.com` |
+| `to:<addr>` | `to:bob@co.com` |
+| `cc:<addr>` | `cc:team@co.com` |
+| `subject:<text>` | `subject:"quarterly report"` |
+| `before:yyyy/MM/dd` | `before:2026/03/01` |
+| `after:yyyy/MM/dd` | `after:2026/01/01` |
+| `newer_than:Xd` | `newer_than:7d` (also `w`, `m`, `y`) |
+| `older_than:Xd` | `older_than:30d` |
+| `has:attachment` | also `document`, `spreadsheet`, `presentation`, `reminder` |
+| `is:unread` | also `read`, `starred`, `pinned`, `unreplied` |
+| `is:shared` | emails shared to any team (alias for `is:shared_email`) |
+| `is:shared_inbox_open` | open items in shared inbox |
+| `is:shared_inbox_done` | completed/closed items in shared inbox |
+| `category:personal` | also `priority`, `notification`, `newsletter`, `invitation`, `invitation_response` |
+| `assigned_to:me` | emails assigned to current user |
+| `assigned_to:<email>` | emails assigned to specific teammate |
+| `assigned_to:unassigned` | shared inbox items with no assignee |
+| `assigned_to:other` | emails assigned to someone else (not me) |
+| `assigned_by:me` | emails delegated by current user |
+| `filename:<name>` | `filename:report.pdf` |
+
+### search
+
+Two modes:
+
+- **With a topic (keyword mode):** Hybrid keyword + semantic search returning up to 20 emails with full bodies, sorted by relevance.
+- **Without a topic (list mode):** Paged compact table of every email matching `--filter` / `--in` across all folders and all accounts, sorted newest first. Same output as `emails`, but the default scope is "all folders" instead of the Unified Inbox. Trash, Spam, and Blocked are excluded (matching Spark's search field) unless `--in` explicitly targets one of those folders.
+
+```bash
+spark search "quarterly report"
+spark search "API integration" --filter "from:alice@co.com"
+spark search "budget" --in user@example.com:Archive
+spark search "vacation" --in user@example.com              # all folders in account
+
+# Keywordless list mode - filter across every folder
+spark search --filter "from:alice@co.com"                  # every email from alice, all folders
+spark search --filter "from:alice@co.com" --in user@example.com
+spark search --filter "is:unread newer_than:7d" --page 2
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<about>` | No | Search topic (positional). Omit to switch to list mode. |
+| `--filter` | No | Gmail-style filter (same operators as `emails`) |
+| `--in` | No | Scope: account, team, folder, or shared inbox. All folders if omitted. |
+| `--page` | No | Page number, 1-based (default: 1). List mode only. |
+| `--page-size` | No | Emails per page (default: 50). List mode only. |
+| `--order` | No | Sort order: `ascending` or `descending`. List mode only. |
+
+**Use `search` with a topic when the user asks about content** - it returns email bodies so you can answer questions. **Use `search` without a topic when you need to filter emails (especially by `from:`) across every folder** - `emails` only sees the Unified Inbox so it can't answer questions like "every email from alice@co.com, anywhere". Use `emails` for plain browsing of Inbox / one folder.
+
+### thread
+
+Print every message in a thread - headers, full plain-text bodies, and attachment info. After the thread summary line, lists **custom (non-system) folder labels** once for the whole thread, using qualified names like `account@domain.com:MyLabel` (same style as `folders`).
+
+```bash
+spark thread 1114                          # by message ID from emails/search output
+spark thread --download-attachments 1114   # also fetch attachments via IMAP
+spark thread "https://sparkmailapp.com/dpl/bl?token=ABC..."  # by Spark deep link
+```
+
+The positional argument accepts either a numeric message ID (the `ID:` line) or a Spark deep link (the `Link:` line) printed by a previous run - `https://sparkmailapp.com/dpl/bl?token=...`, `readdle-spark://bl=...`, or `readdlespark://bl=...`.
+
+Each message's `Attachments:` block is a table with columns `ID`, `Name`, `Size`, `MIME Type`, and `Path`. The `ID` column is the attachment's stable pk - feed it to `attachment` to read the file contents (auto-downloads if necessary). The `Path` column shows the local file or `(not downloaded, ...)` for attachments not yet fetched.
+
+Use `emails` or `search` to find message IDs (the ID column), then `thread` to read the full conversation. Use `folders` to list valid label identifiers for `action attachLabel` / `detachLabel`.
+
+### attachment
+
+Read a single email attachment by its ID (pk) from the `thread` Attachments table. The file is auto-downloaded if it isn't cached locally yet.
+
+```bash
+spark attachment 42                          # print metadata (ID, Name, Size, MIME Type, Path, Message ID)
+spark attachment 42 --stream > report.pdf    # write raw file bytes to stdout
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<id>` | Yes | Attachment ID (pk) from the `thread` Attachments table. |
+| `--stream` | No | Write the raw file bytes to stdout instead of metadata text. Useful inside sandboxed agents that can read the CLI's stdout but not local filesystem paths. The CLI streams the file in 64 KB chunks, so there is no practical size limit. To go the other way - attach a file the app can't read - pipe it into `draft`/`comment` with `--attach-stream`. |
+
+Use `thread` to find attachment IDs (the `ID` column in the `Attachments:` table). The default text output is one `Key: value` per line, easy to parse from scripts.
+
+### draft
+
+**Requires: triage** access level.
+
+Create a new email draft or edit an existing one. The body is written in markdown and converted to HTML.
+
+```bash
+spark draft --to "alice@example.com" --subject "Hello" --body "Hi Alice, ..."
+spark draft --to "alice@co.com" --to "bob@co.com" --cc "carol@co.com" --subject "Meeting" --body "..."
+spark draft --edit 1234 --subject "Updated subject" --body "Updated body"
+spark draft --reply-to 5678 --body "Thanks for the update!"
+spark draft --forward 5678 --to "manager@co.com" --body "FYI"
+spark draft --account "john@gmail.com" --to "alice@co.com" --subject "Hi" --body "..."
+spark draft --to "alice@co.com" --subject "Quick note" --body "..." --no-signature   # send without a signature
+spark draft --edit 1234 --no-signature                                                # strip the signature from an existing draft
+spark draft --to "alice@co.com" --subject "Report" --body "See attached" --attach /path/to/report.pdf
+spark draft --to "alice@co.com" --subject "Files" --body "Two files" --attach /path/to/a.pdf --attach /path/to/b.xlsx
+cat report.pdf | spark draft --to "alice@co.com" --subject "Report" --body "See attached" --attach-stream report.pdf   # pipe a file the app can't read directly
+spark draft --to "client@co.com" --subject "Proposal" --body "..." --team "Engineering" --user alice@co.com --user bob@co.com
+spark draft --edit 1234 --team "Engineering" --user alice@co.com --allow-send
+spark draft --edit 1234 --user carol@co.com           # invite carol on an already-shared draft
+spark draft --edit 1234 --allow-send                  # grant send-on-behalf permission on an already-shared draft
+spark draft --edit 1234 --no-allow-send               # revoke previously-granted send-on-behalf permission
+spark draft --edit 1234 --remove-user alice@co.com    # kick alice from a shared draft (keeps share, comments, other collaborators)
+spark draft --edit 1234 --remove-user alice@co.com --user dave@co.com  # swap collaborators: remove alice, invite dave
+spark draft --edit 1234 --unshare
+spark draft --template "Cold outbound v3" --to "alice@co.com" --placeholder "Project name=Acme Q3" --placeholder "Deadline=Friday EOD"
+spark draft --template 124 --edit 9821 --placeholder "Project name=Acme Q3" --placeholder "Deadline=Friday EOD"
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--to` | No | Recipient address (RFC822). Repeat for multiple. |
+| `--cc` | No | CC address. Repeat for multiple. |
+| `--bcc` | No | BCC address. Repeat for multiple. |
+| `--subject` | No | Subject line. |
+| `--body` | Yes (new, no `--template`) | Body content in markdown. Required for new drafts unless a template provides one. |
+| `--edit` | No | Message ID of an existing draft to update. |
+| `--reply-to` | No | Message ID to reply to. |
+| `--forward` | No | Message ID to forward. |
+| `--account` | No | Account email to send from. Accepts a regular mail account, an alias, or a shared inbox email. |
+| `--attach` | No | Absolute path to a file to attach. Repeat for multiple. The Spark app must be able to read the path; in the sandboxed App Store build a path outside the app's container can't be read and is rejected with a clear error - pipe the file with `--attach-stream` instead. Max 25 MB per file. |
+| `--attach-stream` | No | Attach a single file whose bytes are read from stdin, shown to recipients as `<name>`. Use this when the file is outside the app's sandbox (the App Store build can't read arbitrary paths) - it's the inbound twin of `attachment --stream`. One streamed file per command; combine with `--attach` for paths the app can read. Max 25 MB. Example: `cat report.pdf \| spark draft --edit 123 --attach-stream report.pdf`. |
+| `--team` | No | Team name. Required when you belong to multiple teams. When editing a draft that's already shared, must match the team that owns the share. |
+| `--user` | No | Teammate email to share with. Repeat for multiple. On an already-shared draft this **adds** collaborators without removing existing ones - use `--remove-user` to remove someone. |
+| `--remove-user` | No | Teammate email to **remove** from an already-shared draft. Repeat for multiple. The shared draft, its comments, and the remaining collaborators are preserved (unlike `--unshare`, which tears the whole share down). Requires `--edit <shared-pk>`. Cannot remove yourself - use `--unshare` for that. Can be combined with `--user` in one command to swap collaborators; removals run before invites. |
+| `--allow-send` | No | Grant teammates permission to send the shared draft on your behalf. New share: defaults to off when omitted. Edit of a shared draft: leaves the current value alone when omitted. Mutually exclusive with `--no-allow-send`. |
+| `--no-allow-send` | No | Revoke teammates' permission to send the shared draft on your behalf. Useful when editing a shared draft whose allow-send is currently on. Mutually exclusive with `--allow-send`. |
+| `--unshare` | No | Revert an already-shared draft back to a personal draft. Requires `--edit` and is mutually exclusive with `--team` / `--user` / `--remove-user` / `--allow-send` / `--no-allow-send` **and** with content edits (`--to` / `--cc` / `--bcc` / `--subject` / `--body` / `--attach` / `--attach-stream`) - issue the edit (or per-user removal) and the unshare as separate commands. |
+| `--template` | No | Apply a saved template by ID or name. Combine with `--edit` to overlay onto an existing draft. |
+| `--placeholder` | When template has manual placeholders | Fill a manual template placeholder, format `"<name>=<value>"`. Repeat for each. Auto-fillable placeholders (recipient/self names) are not addressable here - control them via `--to` and `--account`. |
+| `--no-signature` | No | Send without a signature. Suppresses the account's per-mailbox default signature for this draft. On `--edit` it strips a signature already on the draft (the body and quoted thread are kept). Omit the flag to keep using the account default. |
+
+Explicit flags always win over template fields. Use `template <id|name>` to discover the template's manual placeholders before calling `draft --template` - missing manual placeholders cause a hard error before any draft is created. Auto-fillable placeholders that fail to resolve (e.g. recipient name with multiple `--to`) leave a localized label in the body and surface in the response as a warning.
+
+On success the output includes the draft's `ID:` (use it with `--edit` and `action send`) and a `Link:` line with a Spark deep link (`https://sparkmailapp.com/dpl/bl?token=...`) that opens the draft directly in Spark.
+
+**Always give the user the deep link.** After creating or updating a draft, include the `Link:` URL in your response as a clickable markdown link (e.g. `[Open draft in Spark](https://sparkmailapp.com/dpl/bl?token=...)`) so the user can jump straight to the draft to review or send it. Do not tell the user to open Spark and hunt for the draft manually.
+
+Use `emails` to find message IDs for `--edit`, `--reply-to`, and `--forward`.
+Use `accounts` to find account emails for `--account` - both personal accounts and shared inboxes are listed there, and either can be used as the from address when the account has draft & comment access.
+Use `teams` to find team names for `--team` and team member emails for `--user`.
+
+**Threading is critical.** Whenever a new message belongs to an existing conversation, you **must** pass `--reply-to` with the **last message in that thread**. This is what attaches the draft to the conversation (correct In-Reply-To / References headers, same thread in the recipient's mailbox). Without `--reply-to` the draft starts a brand new thread, which is almost always wrong when the user asked you to "reply", "respond", "follow up", "answer", or "ping" anyone in the context of an existing conversation. Use `thread <id>` to inspect the conversation and pick the most recent message's ID as `--reply-to`.
+
+**Follow-ups (no response yet).** When the user asks to follow up with someone you already emailed and they haven't replied yet (e.g. "send Alice a nudge - she never responded to my last email", "bump the proposal thread"), the most recent message in that thread is your own outgoing one. Use that message's ID as `--reply-to` - the follow-up stays attached to the original outgoing message so the recipient sees it as a bump on the existing conversation rather than a new cold email.
+
+Sharing is triggered by the presence of `--team` or `--user`; teams with exactly one other active member auto-share with everyone, otherwise `--user` is required.
+To add collaborators or change the allow-send setting on an existing shared draft, use `--edit <pk>` together with the sharing flags - the change is applied to the existing share instead of creating a new one.
+To toggle allow-send off, pass `--no-allow-send`.
+To remove a specific collaborator without tearing the share down, pass `--remove-user <email>`; the shared draft, its comments, and the remaining collaborators stay intact. Combine `--user` and `--remove-user` in one command to swap collaborators in a single operation - removals run before invites.
+Content edits (`--to`, `--cc`, `--bcc`, `--subject`, `--body`, `--attach`) and sharing updates (`--team`, `--user`, `--remove-user`, `--allow-send`, `--no-allow-send`) must be issued as separate `draft` commands.
+
+### templates
+
+List Spark message templates - the saved drafts users can apply via `draft --template`. Templates round-trip from desktop, so anything saved on the user's computer shows up here.
+
+```bash
+spark templates                          # all personal + team templates
+spark templates --personal               # only personal templates
+spark templates --team "Marketing"       # only that team's templates
+spark templates --page 2 --page-size 20  # pagination
+```
+
+Output columns: `ID`, `Scope` (Personal / `<team name>`), `Name`, `Subject` (truncated to 40 chars), `Modified`. Use the `ID` or `Name` value with `template <id|name>` and `draft --template`.
+
+### template
+
+**Read-only.** Show a single template's full contents and its placeholder requirements. Run this before `draft --template` so you know which `--placeholder "<name>=<value>"` arguments the template needs.
+
+```bash
+spark template 123                       # by ID
+spark template "Welcome reply"           # by name (case-insensitive)
+```
+
+Output includes scope, recipients, subject, body (HTML stripped to text), attachments, and a `Placeholders:` section listing every placeholder in the template:
+
+- `[auto]` - auto-fillable (recipient/self name). Resolved from `--to` and `--account` when applied. **Not** overridable via `--placeholder`.
+- `[manual]` - free-form placeholder. Required: must be passed as `--placeholder "<name>=<value>"` to `draft --template`.
+
+If a name matches more than one template, you'll get an error listing the matching IDs - disambiguate by ID.
+
+### comment
+
+**Requires: triage** access level.
+
+Post a team comment (chat message) on a thread. If the thread is not yet shared, it will be shared automatically. Supports text comments, file attachments, or both. Use `--edit` to update an existing comment.
+
+```bash
+spark comment 1234 --body "Looks good, let's proceed."
+spark comment 1234 --body "Please review this" --team "Engineering"
+spark comment 1234 --body "FYI" --team "Engineering" --user alice@co.com --user bob@co.com
+spark comment 1234 --attach /path/to/screenshot.png
+spark comment 1234 --body "See attached" --attach /path/to/report.pdf --attach /path/to/data.csv
+cat screenshot.png | spark comment 1234 --attach-stream screenshot.png   # pipe a file the app can't read directly
+spark comment --edit 5678 --body "Updated comment text"
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<message-id>` | Yes (post) | Message ID of a message in the thread to comment on. |
+| `--body` | When no `--attach` | Comment text to post. Required when using `--edit`. |
+| `--attach` | When no `--body` | Absolute path to a file to attach. Repeat for multiple files. Each file is sent as a separate message. Cannot be used with `--edit`. The Spark app must be able to read the path; in the sandboxed App Store build a path outside the app's container can't be read and is rejected with a clear error - pipe the file with `--attach-stream` instead. Max 25 MB per file. |
+| `--attach-stream` | When no `--body` | Attach a single file whose bytes are read from stdin, shown as `<name>`, sent as its own comment message. Use this when the file is outside the app's sandbox (the App Store build can't read arbitrary paths) - it's the inbound twin of `attachment --stream`. One streamed file per command; cannot be used with `--edit`. Max 25 MB. Example: `cat shot.png \| spark comment 456 --attach-stream shot.png --team "Engineering"`. |
+| `--edit` | No | Message ID of an existing comment to edit. Requires `--body`. |
+| `--team` | When >1 team | Team name. Required when you belong to multiple teams. |
+| `--user` | When team >2 members | Teammate email to share with. Repeat for multiple. Only used when auto-sharing an unshared thread. For teams with 2 or fewer members, the whole team is shared with automatically. |
+
+Use `emails` to find message IDs. Use `thread` to see comment IDs in a conversation. Use `team` to list teams and their members.
+
+### events
+
+List calendar events for a time range.
+
+```bash
+spark events                                          # today's remaining events
+spark events --tomorrow
+spark events --week
+spark events --week --in user@example.com             # specific account
+spark events --week --in user@example.com:Work        # specific calendar
+spark events --start 2026-03-16 --end 2026-03-20      # custom range
+```
+
+Date formats: `yyyy-MM-dd`, `dd/MM/yyyy`, or `yyyy-MM-ddTHH:mm`.
+
+Run `accounts` to see available calendar accounts and calendar names.
+
+### event
+
+**Requires: send** access level on the target calendar's owning account. Every mode can emit mail through the calendar service (invitations on create / update, iTIP UPDATE / CANCEL on update / delete of attendee-bearing events, an iTIP REPLY on rsvp), and attaching attendees makes the event discoverable by the provider's invitation channel independent of email, so the whole command sits at `send`.
+
+Create, update, delete, or RSVP to a calendar event, including managing its attendees. Use `--add` / `--remove` on `create` or `update` to attach or detach attendees and send invitations / cancellations through the calendar provider (CalDAV / Google / Exchange).
+
+```bash
+spark event create --title "Sync" --start 2026-07-01T12:00 --end 2026-07-01T13:00
+spark event create --title "OOO" --start 2026-07-01 --all-day
+spark event create --title "Standup" --start 2026-07-01T09:00 --end 2026-07-01T09:15 --video-conference auto
+spark event create --title "Sync" --start 2026-07-01T10:00 --end 2026-07-01T10:30 --video-conference zoom
+spark event create --title "1:1" --start 2026-07-01T14:00 --end 2026-07-01T14:30 --calendar "user@co.com:Work"
+spark event create --title "Sync" --start 2026-07-01T12:00 --add "alice@co.com,bob@co.com"   # create + invite
+spark event update ABC-123 --title "New title"
+spark event update ABC-123 --location "Room 7"
+spark event update ABC-123 --video-conference meet   # add a meeting link
+spark event update ABC-123 --add alice@co.com --remove bob@co.com   # swap attendees
+spark event delete ABC-123
+spark event rsvp ABC-123 accept     # calendar event ID
+spark event rsvp ABC-123 decline
+spark event rsvp 44268 maybe        # invitation email message ID
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `mode` | Yes | `create`, `update`, `delete`, or `rsvp` (positional). |
+| `event_id` | For `update`/`delete`/`rsvp` | Positional, second arg. For `update`/`delete`: a calendar event ID (use `events`). For `rsvp`: either a calendar event ID **or** the message ID of the invitation email (use `emails` / `thread`). |
+| `status` | For `rsvp` | RSVP status (positional, third arg): `accept`, `decline`, or `maybe`. |
+| `--title` | No | Event title / summary. |
+| `--start` | Yes (for `create`) | Start date/time (`yyyy-MM-dd`, `dd/MM/yyyy`, `yyyy-MM-ddTHH:mm`, or `yyyy-MM-ddTHH:mm:ssXXX`). |
+| `--end` | No | End date/time. |
+| `--all-day` | No | Mark the event as all-day. |
+| `--description` | No | Event description / notes. |
+| `--alerts` | No | Comma-separated alert offsets (`Ns` for N seconds before, e.g. `300s,600s`) or absolute dates. |
+| `--location` | No | Event location text. |
+| `--video-conference` | No | Attach a video conference (value required). `auto` auto-picks the account's type (recently used, else default); `meet`, `zoom`, or `teams` selects a specific one and errors if the account doesn't support it. |
+| `--calendar` | No | Target calendar for `create`. Format: `email@domain.com` (account's default calendar) or `email@domain.com:Name` (specific named calendar). |
+| `--add` | No | Attendee email address(es) to invite (create / update only). Repeat the flag or pass a comma-separated list. New attendees receive an iTIP REQUEST (invitation). |
+| `--remove` | No | Attendee email address(es) to remove (update only). Repeat the flag or pass a comma-separated list. Removed attendees receive an iTIP CANCEL. The organizer cannot be removed. |
+
+**Attendees (`--add` / `--remove`):**
+- Only valid on `create` and `update`; passing them to `delete` or `rsvp` is refused. Combine both in one `update` to swap attendees - removals run before additions.
+- Adding or removing attendees always emits iTIP mail (REQUEST / CANCEL). An event with no attendees stays invisible to the calendar service's invitation channel.
+- Attaching attendees makes the event discoverable by the calendar provider's invitation channel (including Google Calendar's same-provider auto-add behavior), independent of email delivery - which is why the whole command requires `send`.
+
+**`event update` semantics:**
+- `--video-conference` attaches a meeting link (`meet` / `zoom` / `teams`, or `auto`) to an existing event, generated through the same path as `create`. On an event with attendees this is a shared change, so it sends the iTIP UPDATE.
+- Event with **no attendees** → local update, no mail goes out.
+- Event **with attendees** → update + iTIP UPDATE sent to all attendees so their calendars reflect the new state. Output reports the attendee count.
+- An alerts-only edit is a personal reminder and notifies nobody, even on an event with attendees.
+
+**`event delete` semantics:**
+- Event with **no attendees** → local delete, no mail goes out.
+- Event **with attendees** → delete + iTIP CANCEL sent to all attendees so their calendars get cleaned up too. Output reports the attendee count. Deleting without the cancellation would orphan the invitation on attendees' calendars (most visibly on Google's same-provider auto-add channel).
+
+**`event rsvp` semantics:**
+- Sets *your own* attending status on an invitation: `accept`, `decline`, or `maybe` (alias for tentative). Responding emits an iTIP REPLY back to the organizer.
+- The id can be **either** a calendar event ID **or** the message ID of the invitation email. Many providers (Google included) leave an unanswered invite sitting in the inbox without adding it to the calendar, so when the user asks you to respond to an invitation, look it up with `emails` / `thread` and pass that **message ID** - you do not need a calendar event. When the invite *has* been auto-added to the calendar, a calendar event ID works too.
+- For a message ID, the reply mirrors Spark Desktop: it updates the matching calendar event if one is synced, otherwise it mails the iTIP REPLY straight to the organizer (and, on `accept`, adds the event to your calendar).
+- Errors if the target is not an invitation you can respond to (a plain email, your own organized event with no RSVP, or a provider that does not allow responding).
+- For a calendar event, re-RSVPing to the status you already hold is a no-op and reported as such.
+
+Typical flow when scheduling a new meeting: call `event create ...` to lay down the event first, confirm the time and details with the user, then call `event update <event-id> --add ...` to push invitations - so the user can review (or you can revise) the event before any external email goes out. When you already have the attendees, `event create ... --add ...` does both in one step.
+
+Run `accounts` to see writable calendars and the access level on each account.
+
+### availability
+
+Find free time slots. Without `--attendees`, shows the user's own availability. With `--attendees`, computes mutual free windows.
+
+```bash
+spark availability                                                        # today
+spark availability --tomorrow
+spark availability --week --attendees alice@co.com
+spark availability --start 2026-03-16 --end 2026-03-20 --attendees a@co.com,b@co.com
+```
+
+Free slots are within working hours (08:00-20:00), skip weekends, and ignore events marked "free".
+
+### contacts
+
+Search contacts by name or email. Strict match first, then fuzzy fallback.
+
+```bash
+spark contacts "john"
+spark contacts "example.com"
+```
+
+### team
+
+Show team info - metadata, shared inboxes with members, full member list, assigned emails, assignment summary.
+
+```bash
+spark team                     # list available teams
+spark team "Readdle"           # specific team
+```
+
+### meetings
+
+List meeting transcripts with optional filters and pagination.
+
+```bash
+spark meetings
+spark meetings --filter "newer_than:30d"
+spark meetings --filter "subject:standup" --page-size 10
+```
+
+Filter operators: `subject:<text>`, `before:yyyy/MM/dd`, `after:yyyy/MM/dd`, `newer_than:Xd`, `older_than:Xd`.
+
+### meeting
+
+Read a single meeting transcript's summary. Optionally include the full transcript and/or notes.
+
+```bash
+spark meeting 42                            # summary only
+spark meeting --transcript 42               # include transcript
+spark meeting --notes 42                    # include notes
+spark meeting --transcript --notes 42       # everything
+spark meeting "https://sparkmailapp.com/dpl/bl?token=ABC..."  # by Spark deep link
+```
+
+The positional argument accepts either a numeric meeting message ID or a Spark deep link.
+
+Use `meetings` to find meeting IDs.
+
+### action
+
+**Requires: triage** access level.
+
+Perform an action on one or more emails. Supports standard email actions and team actions.
+
+```bash
+spark action <action-name> <message-id...> [options]
+```
+
+Supported actions:
+- `pin` - Pin the message to keep it at the top of the list
+- `unpin` - Remove the pin from the message
+- `mute` - Mute the thread to stop receiving notifications
+- `unmute` - Unmute a previously muted thread
+- `snooze` - Snooze the message until a specific date (requires `--date`)
+- `unsnooze` - Remove the snooze and return the message to the inbox
+- `changeReminder` - Set a follow-up reminder if no reply by the date (requires `--date`)
+- `clearReminder` - Remove the follow-up reminder from the message
+- `setAside` - Set the message aside for later review
+- `archive` - Archive the message, removing it from the inbox
+- `moveToInbox` - Move the message back to the inbox
+- `moveToTrash` - Move the message to trash
+- `moveToFolder` - Move the message to a specific folder (requires `--folder`)
+- `attachLabel` - Attach a Gmail or Spark Team label without removing other labels (requires `--folder`)
+- `detachLabel` - Remove a Gmail or Spark Team label from the message (requires `--folder`)
+- `markAsDone` - Mark the message as done
+- `markAsUndone` - Mark the message as not done
+- `markAsSeen` - Mark the message as read
+- `markAsUnseen` - Mark the message as unread
+- `markAsSpam` - Mark the message as spam
+- `markThreadAsPriority` - Mark the thread as priority
+- `unmarkThreadAsPriority` - Remove the priority mark from the thread
+- `unsubscribe` - Unsubscribe from the sender or mailing list
+- `changeCategoryPersonal` - Change the email category to Personal
+- `changeCategoryNotification` - Change the email category to Notification
+- `changeCategoryNewsletters` - Change the email category to Newsletter
+- `shareInTeam` - Share the thread with teammates (requires `--team` when multiple teams)
+- `assign` - Assign the email to a teammate (requires `--assignee`)
+- `delegationComplete` - Mark the delegation as complete
+- `delegationReopen` - Reopen a completed delegation
+
+**`send` verb (requires send access):**
+
+Sends an existing draft (created with `spark draft` or in Spark Desktop) through the owning account's outbound mail pipeline. Same validation as the desktop composer: the draft must live on an account whose access level is **send** (Settings -> AI Agents), have at least one recipient, a non-empty subject, all attachments uploaded, and no unresolved manual template placeholders.
+
+```bash
+spark action send 1234
+```
+
+Output reports the original draft ID and the PK of the sent message:
+
+`Draft 1234 sent. Sent message ID: 5678.`
+
+Typical flow: `spark draft ...` to compose, review the draft, then `spark action send <pk>` to commit. Splitting the two operations means you (or the user) can edit the draft before any external mail is emitted - `spark draft` alone never sends.
+
+`send` accepts multiple draft IDs in one call (each runs through validation independently and the response reports per-draft success/failure), but the common case is a single id.
+
+**Scheduled send ("Send Later"):** pass an optional `--date` to schedule the draft instead of sending it now. The date must be in the future (formats: `yyyy-MM-dd`, `dd/MM/yyyy`, `yyyy-MM-ddTHH:mm`); a past or malformed date is rejected before anything is sent.
+
+```bash
+spark action send 1234 --date 2026-04-10T09:00
+```
+
+Output confirms the schedule: `Draft 1234 scheduled to send on 2026-04-10 09:00. Message ID: 5678.` The message sits in the outbox and is delivered at that time.
+
+**Manage an already-scheduled ("Send Later") message** by targeting its message ID with `send`:
+
+- **Reschedule:** `send` with a new `--date` updates the existing schedule (it is no longer a plain draft, so this does not create a new message):
+
+```bash
+spark action send 5678 --date 2026-04-12T15:00
+```
+
+Output: `Message 5678 rescheduled to send on 2026-04-12 15:00. Message ID: 5678.`
+
+- **Send now:** `send` with no `--date` drops the schedule and sends it immediately:
+
+```bash
+spark action send 5678
+```
+
+Output: `Scheduled message 5678 sent now. Message ID: 5678.`
+
+- **Unschedule:** `unschedule` cancels the schedule and returns the message to drafts (so you can edit it or send it later):
+
+```bash
+spark action unschedule 5678
+```
+
+Output: `Message 5678 unscheduled - returned to drafts. Find it in the Drafts folder.` Clearing the schedule mints a fresh draft, so the original ID (5678) no longer resolves - re-list the Drafts folder to get the new draft ID before editing or sending it.
+
+Both `send` (with or without `--date`) on a scheduled message and `unschedule` require send access on the owning account.
+
+Options:
+- `--date` - required for `snooze` and `changeReminder`, optional for `assign` as due date (formats: `yyyy-MM-dd`, `dd/MM/yyyy`, `yyyy-MM-ddTHH:mm`)
+- `--folder` - required for `moveToFolder`, `attachLabel`, and `detachLabel` (qualified name: `email@domain.com:FolderName`; use `folders` to list labels including shared inboxes)
+- `--team` - team name for team actions; required when you belong to multiple teams
+- `--user` - teammate email to share with for `shareInTeam`; repeat for multiple users; required when team has more than 2 members
+- `--assignee` - teammate email to assign the email to for `assign`
+- `--comment` - comment text for the `assign` action
+
+```bash
+spark action pin 12345                                          # pin a message
+spark action archive 100 200 300                                # archive multiple messages
+spark action markAsSeen 100 200                                 # mark as read
+spark action snooze 12345 --date 2026-04-10T09:00               # snooze until date/time
+spark action snooze 12345 --date 2026-04-10                     # snooze until date
+spark action moveToFolder 12345 --folder "user@example.com:Archive"  # move to folder
+spark action attachLabel 12345 --folder "user@gmail.com:MyLabel"       # add Gmail/Team label
+spark action detachLabel 12345 --folder "shared@company.com:SomeLabel"  # remove label
+spark action changeReminder 12345 --date 2026-04-15             # set reminder
+spark action shareInTeam 1234 --team "Engineering" --user alice@co.com  # share with teammate
+spark action shareInTeam 1234 --user alice@co.com --user bob@co.com    # share with multiple
+spark action assign 1234 --assignee bob@co.com                  # assign to teammate
+spark action assign 1234 --assignee bob@co.com --date 2026-04-15 --comment "Please review"
+spark action delegationComplete 1234                            # mark delegation done
+spark action delegationComplete 100 200 300                     # complete multiple delegations
+spark action delegationReopen 1234                              # reopen delegation
+```
+
+Use the `emails` command to find message IDs. Use `folders` to resolve qualified names for `moveToFolder`, `attachLabel`, and `detachLabel`. Use `team` to list teams and members for team actions.
+
+### contact-action
+
+**Requires: triage** access level.
+
+Perform an action on one or more contacts by email address.
+
+```bash
+spark contact-action <action-name> <email...>
+```
+
+Supported actions:
+
+| Action | Description |
+|--------|-------------|
+| `changeCategoryPersonal` | Change the contact's email category to Personal |
+| `changeCategoryNotification` | Change the contact's email category to Notification |
+| `changeCategoryNewsletters` | Change the contact's email category to Newsletter |
+| `groupEmailsFromContact` | Group emails from the contact by category |
+| `groupEmailsFromContactAndShowInInbox` | Group emails from the contact and show in inbox |
+| `ungroupEmailsFromContact` | Ungroup emails from the contact |
+| `markContactAsImportant` | Enable notifications for the contact |
+| `unmarkContactAsImportant` | Disable notifications for the contact |
+| `markContactAsPrimary` | Mark the contact as priority (auto-prioritize emails) |
+| `unmarkContactAsPrimary` | Remove priority mark from the contact |
+| `acceptContact` | Accept or unblock the contact (bypass Gatekeeper) |
+| `blockContact` | Block the contact |
+| `acceptDomain` | Accept or unblock the contact's entire domain |
+| `blockDomain` | Block the contact's entire domain |
+| `enableAutosummaryForContact` | Enable auto-summary for emails from the contact |
+| `disableAutosummaryForContact` | Disable auto-summary for emails from the contact |
+
+Examples:
+
+```bash
+spark contact-action blockContact spammer@example.com
+spark contact-action acceptContact alice@co.com bob@co.com
+spark contact-action changeCategoryPersonal alice@co.com
+spark contact-action markContactAsPrimary ceo@company.com
+spark contact-action enableAutosummaryForContact newsletter@example.com
+```
+
+Use the `contacts` command to look up email addresses.
+
+## Smart Categories
+
+Spark automatically classifies incoming email into six categories. Use the `category:` filter operator with `emails` and `search` to view mail by category, and use `action` / `contact-action` to reclassify and tune.
+
+| Category | Filter | Typical Content |
+|----------|--------|-----------------|
+| Priority | `category:priority` | Auto-prioritized or manually marked as priority |
+| People | `category:personal` | Direct person-to-person email |
+| Notifications | `category:notification` | Service notifications, alerts, receipts |
+| Newsletters | `category:newsletter` | Subscriptions, digests, marketing |
+| Invites | `category:invitation` | Calendar invitations |
+| Invite Responses | `category:invitation_response` | RSVPs, accepts, declines |
+
+**Browse by category** (read-only):
+
+```bash
+spark emails Inbox --filter "category:priority is:unread"       # unread priority mail
+spark emails Inbox --filter "category:personal is:unread"       # unread people mail
+spark emails Inbox --filter "category:invitation"               # pending invites
+spark emails Inbox --filter "category:notification is:unread"   # unread notifications
+spark emails Inbox --filter "category:newsletter newer_than:7d" # recent newsletters
+```
+
+**Reclassify a message** (triage):
+
+```bash
+spark action changeCategoryPersonal <id>       # move to People
+spark action changeCategoryNotification <id>   # move to Notifications
+spark action changeCategoryNewsletters <id>    # move to Newsletters
+```
+
+**Tune per-contact category rules** (triage) - changes apply to all future mail from the sender:
+
+```bash
+spark contact-action changeCategoryPersonal sender@example.com         # reclassify as People
+spark contact-action changeCategoryNewsletters sender@example.com      # reclassify as Newsletters
+spark contact-action groupEmailsFromContact sender@example.com         # group by category
+spark contact-action markContactAsImportant vip@example.com            # enable notifications
+spark contact-action markContactAsPrimary ceo@example.com              # auto-prioritize
+spark contact-action enableAutosummaryForContact newsletter@example.com # AI summaries
+```
+
+**Category-first triage pattern:** Process inbox in priority order - priority first, then people, then invites, then notifications, then newsletters. This ensures the most important messages get attention first.
+
+## Typical Workflows
+
+**Answer a question about emails:**
+1. `spark search "topic"` - find relevant emails with bodies
+2. Read the output and answer the user's question
+
+**Find and read a specific email:**
+1. `spark emails --filter "from:sender subject:keyword"` - locate the email
+2. `spark thread <ID>` - read the full conversation
+
+**Draft a reply:**
+1. `spark emails --filter "from:sender"` - find the email
+2. `spark draft --reply-to <ID> --body "Thanks for the update!"`
+3. Give the user the `Link:` from the output as a clickable markdown link so they can review the draft in Spark
+
+**Send an email from a saved template:**
+1. `spark templates` - list templates (or `spark templates --personal` / `--team "<name>"`)
+2. `spark template "<name>"` - inspect placeholders before applying
+3. `spark draft --template "<name>" --to <recipient> --placeholder "<manual>=<value>"` - create the draft (repeat `--placeholder` for each manual one)
+
+**Check someone's schedule for a meeting:**
+1. `spark availability --tomorrow --attendees alice@co.com,bob@co.com`
+2. Suggest a time from the free slots
+
+**Comment on a shared thread:**
+1. `spark emails --filter "from:sender"` - find the email
+2. `spark comment <ID> --body "Looks good, approved!"`
+
+**Get team workload overview:**
+1. `spark team "Team Name"` - see members and assigned emails
+
+**Look up a contact:**
+1. `spark contacts "name or domain"` - find their email address
+
+**Perform an action on emails:**
+1. `spark emails --filter "from:sender"` - find the email
+2. `spark action archive <ID>` - archive it (or pin, snooze, etc.)
+
+**Share an email with your team:**
+1. `spark emails --filter "subject:keyword"` - find the email
+2. `spark action shareInTeam <ID> --user alice@co.com` - share with a teammate
+
+**Delegate an email to a teammate:**
+1. `spark emails --filter "subject:keyword"` - find the email
+2. `spark action assign <ID> --assignee bob@co.com --date 2026-04-15 --comment "Please handle this"`
+
+**Mark delegated emails as done:**
+1. `spark emails --filter "subject:keyword"` - find the email(s)
+2. `spark action delegationComplete <ID1> <ID2>` - mark multiple as complete
+
+**Find unassigned shared inbox emails:**
+1. `spark emails shared@co.com:Inbox --filter "assigned_to:unassigned"` - list unassigned items
+2. `spark action assign <ID> --assignee bob@co.com` - assign to a teammate
+
+**Review what's assigned to a teammate:**
+1. `spark emails --filter "assigned_to:bob@co.com"` - see their assignments
+2. `spark emails --filter "is:shared_inbox_open"` - all open shared inbox items
+3. `spark emails --filter "is:shared_inbox_done"` - completed items
+
+**Manage a contact:**
+1. `spark contacts "name or domain"` - find the contact email
+2. `spark contact-action blockContact spammer@example.com` - block them (or accept, change category, etc.)
+
+## Keeping this skill up to date
+
+The CLI and this skill share a single version (`metadata.version` in the front-matter above). New features in newer Spark Desktop releases ship with an updated embedded skill. Backward compatibility is guaranteed within a major version, so the commands and flags documented here keep working - but newly added features won't appear in this file until it is reinstalled.
+
+Check for an update when - and only when - you hit one of these signals:
+
+- The user asks about a Spark feature, command, or flag that isn't documented here.
+- A `spark` command fails with an "unknown command" or "unknown option" error you didn't expect.
+- The user explicitly says they upgraded Spark or that the skill is out of date.
+
+In those cases:
+
+```bash
+spark --version
+```
+
+If the printed version is greater than `metadata.version` above, refresh this file before answering. `spark skill` prints SKILL.md to stdout - capture it and write it back over the file you're reading right now (the path is in your context). For example:
+
+```bash
+mkdir -p <parent-of-use-spark>/use-spark
+spark skill > <parent-of-use-spark>/use-spark/SKILL.md
+```
+
+`<parent-of-use-spark>` is the directory containing the `use-spark/` folder this `SKILL.md` lives in. If you have a file-write tool, you can also pipe `spark skill` output directly through it - the CLI itself does not write any files.
+
+Do not check on every session or before every command - this skill is the source of truth unless one of the signals above tells you otherwise.
+
+## Tips
+
+- Always quote multi-word arguments: `spark search "project update"`
+- Combine filter operators in a single `--filter` string: `--filter "from:alice@co.com is:unread newer_than:7d"`
+- Use `folders` to discover exact folder identifiers before passing them to `emails` or `search --in`
+- Use `accounts` to discover calendar names before passing them to `events --in`
+- The `search` command is best for topic-based queries; `emails` is best for browsing/filtering by metadata
+- `thread` returns the full conversation - use it when you need the complete email text, not just metadata
+- Use `draft` to compose emails - it supports new drafts, replies, forwards, and editing existing drafts
+- After creating a draft, always share its `Link:` deep link with the user as a clickable markdown link instead of asking them to open Spark
+- Use `comment` to post team chat messages on threads - it auto-shares the thread if needed
+- Use `action` to perform email actions like pin, archive, snooze, move to folder, and more
+- Use `contact-action` to manage contacts - block, accept, change category, toggle auto-summary, and more

--- a/scripts/claude-hooks-cases/destructive-git.txt
+++ b/scripts/claude-hooks-cases/destructive-git.txt
@@ -1,4 +1,4 @@
-# hook: Checking for destructive git
+# script: deny-destructive-git.sh
 #
 # git clean deletes untracked files, which no reflog can restore, so it is the
 # reason this hook exists. git reset --hard is covered too, though git-ai

--- a/scripts/claude-hooks-cases/destructive-push.txt
+++ b/scripts/claude-hooks-cases/destructive-push.txt
@@ -1,4 +1,4 @@
-# hook: Checking for destructive push
+# script: deny-destructive-push.sh
 #
 # Force push and its equivalents. The + refspec form was verified to slip past
 # an earlier version of this hook, because it contains neither --force nor -f.

--- a/scripts/claude-hooks-cases/interpreter-oneliners.txt
+++ b/scripts/claude-hooks-cases/interpreter-oneliners.txt
@@ -1,4 +1,4 @@
-# hook: Checking interpreter one-liners
+# script: deny-interpreter-oneliners.sh
 #
 # An interpreter one-liner reaches the filesystem without matching any Bash deny
 # rule. This hook fires only when BOTH conditions hold: the command runs inline

--- a/scripts/claude-hooks-cases/recursive-rm.txt
+++ b/scripts/claude-hooks-cases/recursive-rm.txt
@@ -1,4 +1,4 @@
-# hook: Checking for recursive rm
+# script: deny-recursive-rm.sh
 #
 # Any recursive rm, regardless of flag order or spelling. -f is deliberately not
 # required: an agent shell has nobody to answer an interactive prompt, so rm -r

--- a/scripts/test-claude-hooks.sh
+++ b/scripts/test-claude-hooks.sh
@@ -10,18 +10,12 @@
 # so treat a change to any hook as a reason to run this first.
 #
 # The hook body is never duplicated here, so this tests what actually runs. A
-# case file locates its hook one of two ways:
+# case file names its hook with a `# script: <name>.sh` header, resolved to
+# dot_claude/hooks/executable_<name>.sh.
 #
-#   # script: <name>.sh   the hook lives in dot_claude/hooks/executable_<name>.sh
-#   # hook: <statusMessage>   the hook is still inline in the settings file
-#
-# The second form is the pre-migration path and goes away once every hook has
-# been extracted (see docs/plan/hooks-to-scripts-20260731.md). While both exist,
-# a case file carrying both headers takes the script.
-#
-# For an extracted hook the runner also asserts that the settings file actually
-# references the script. Without that, a typo in the hook command leaves every
-# case passing against a script that production never invokes.
+# The runner also asserts that the settings file references the script. Without
+# that, a typo in the hook command leaves every case passing against a script
+# production never invokes.
 #
 # Usage:
 #   scripts/test-claude-hooks.sh            # run every suite
@@ -49,36 +43,24 @@ for case_file in "$cases_dir"/*.txt; do
     [ -n "$filter" ] && [[ $name != *"$filter"* ]] && continue
 
     script_name=$(sed -n 's/^# script: //p' "$case_file" | head -1)
-    status_message=$(sed -n 's/^# hook: //p' "$case_file" | head -1)
-    script_path=""
-    hook_cmd=""
+    if [ -z "$script_name" ]; then
+        echo "FAIL $name: case file has no '# script: <name>.sh' header"
+        total_fail=$((total_fail + 1))
+        continue
+    fi
 
-    if [ -n "$script_name" ]; then
-        script_path="$hooks_dir/executable_$script_name"
-        if [ ! -f "$script_path" ]; then
-            echo "FAIL $name: '# script: $script_name' names a file that does not exist: $script_path"
-            total_fail=$((total_fail + 1))
-            continue
-        fi
-        # The script must be what production runs, not just what passes here.
-        if ! jq -e --arg n "$script_name" \
-            '[.hooks[]?[]?.hooks[]?.command // empty | select(contains($n))] | length > 0' \
-            "$settings" >/dev/null; then
-            echo "FAIL $name: $script_name is not referenced by any hook command in settings"
-            total_fail=$((total_fail + 1))
-            continue
-        fi
-    elif [ -n "$status_message" ]; then
-        hook_cmd=$(jq -r --arg s "$status_message" \
-            '.hooks.PreToolUse[].hooks[] | select(.statusMessage == $s) | .command' \
-            "$settings")
-        if [ -z "$hook_cmd" ]; then
-            echo "FAIL $name: no hook in settings with statusMessage '$status_message'"
-            total_fail=$((total_fail + 1))
-            continue
-        fi
-    else
-        echo "FAIL $name: case file has no '# script:' or '# hook:' header"
+    script_path="$hooks_dir/executable_$script_name"
+    if [ ! -f "$script_path" ]; then
+        echo "FAIL $name: '# script: $script_name' names a file that does not exist: $script_path"
+        total_fail=$((total_fail + 1))
+        continue
+    fi
+
+    # The script must be what production runs, not just what passes here.
+    if ! jq -e --arg n "$script_name" \
+        '[.hooks[]?[]?.hooks[]?.command // empty | select(contains($n))] | length > 0' \
+        "$settings" >/dev/null; then
+        echo "FAIL $name: $script_name is not referenced by any hook command in settings"
         total_fail=$((total_fail + 1))
         continue
     fi
@@ -91,11 +73,7 @@ for case_file in "$cases_dir"/*.txt; do
 
         payload=$(jq -cn --arg c "$command_under_test" \
             '{tool_name: "Bash", tool_input: {command: $c}}')
-        if [ -n "$script_path" ]; then
-            out=$(printf '%s' "$payload" | bash "$script_path")
-        else
-            out=$(printf '%s' "$payload" | sh -c "$hook_cmd")
-        fi
+        out=$(printf '%s' "$payload" | bash "$script_path")
         rc=$?
 
         # A no-match grep exits 1, which is the normal path. A hook that lets

--- a/scripts/test-claude-hooks.sh
+++ b/scripts/test-claude-hooks.sh
@@ -9,8 +9,19 @@
 # Every regex here has been rewritten at least once after a hole was found in it,
 # so treat a change to any hook as a reason to run this first.
 #
-# The hook commands are read out of the settings file rather than duplicated, so
-# this tests what actually runs. Each case file names its hook by statusMessage.
+# The hook body is never duplicated here, so this tests what actually runs. A
+# case file locates its hook one of two ways:
+#
+#   # script: <name>.sh   the hook lives in dot_claude/hooks/executable_<name>.sh
+#   # hook: <statusMessage>   the hook is still inline in the settings file
+#
+# The second form is the pre-migration path and goes away once every hook has
+# been extracted (see docs/plan/hooks-to-scripts-20260731.md). While both exist,
+# a case file carrying both headers takes the script.
+#
+# For an extracted hook the runner also asserts that the settings file actually
+# references the script. Without that, a typo in the hook command leaves every
+# case passing against a script that production never invokes.
 #
 # Usage:
 #   scripts/test-claude-hooks.sh            # run every suite
@@ -23,6 +34,7 @@ set -uo pipefail
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 settings="$repo_root/dot_claude/private_settings.json"
 cases_dir="$repo_root/scripts/claude-hooks-cases"
+hooks_dir="$repo_root/dot_claude/hooks"
 filter=${1:-}
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
@@ -36,18 +48,37 @@ for case_file in "$cases_dir"/*.txt; do
     name=$(basename "$case_file" .txt)
     [ -n "$filter" ] && [[ $name != *"$filter"* ]] && continue
 
+    script_name=$(sed -n 's/^# script: //p' "$case_file" | head -1)
     status_message=$(sed -n 's/^# hook: //p' "$case_file" | head -1)
-    if [ -z "$status_message" ]; then
-        echo "FAIL $name: case file has no '# hook: <statusMessage>' header"
-        total_fail=$((total_fail + 1))
-        continue
-    fi
+    script_path=""
+    hook_cmd=""
 
-    hook_cmd=$(jq -r --arg s "$status_message" \
-        '.hooks.PreToolUse[].hooks[] | select(.statusMessage == $s) | .command' \
-        "$settings")
-    if [ -z "$hook_cmd" ]; then
-        echo "FAIL $name: no hook in settings with statusMessage '$status_message'"
+    if [ -n "$script_name" ]; then
+        script_path="$hooks_dir/executable_$script_name"
+        if [ ! -f "$script_path" ]; then
+            echo "FAIL $name: '# script: $script_name' names a file that does not exist: $script_path"
+            total_fail=$((total_fail + 1))
+            continue
+        fi
+        # The script must be what production runs, not just what passes here.
+        if ! jq -e --arg n "$script_name" \
+            '[.hooks[]?[]?.hooks[]?.command // empty | select(contains($n))] | length > 0' \
+            "$settings" >/dev/null; then
+            echo "FAIL $name: $script_name is not referenced by any hook command in settings"
+            total_fail=$((total_fail + 1))
+            continue
+        fi
+    elif [ -n "$status_message" ]; then
+        hook_cmd=$(jq -r --arg s "$status_message" \
+            '.hooks.PreToolUse[].hooks[] | select(.statusMessage == $s) | .command' \
+            "$settings")
+        if [ -z "$hook_cmd" ]; then
+            echo "FAIL $name: no hook in settings with statusMessage '$status_message'"
+            total_fail=$((total_fail + 1))
+            continue
+        fi
+    else
+        echo "FAIL $name: case file has no '# script:' or '# hook:' header"
         total_fail=$((total_fail + 1))
         continue
     fi
@@ -60,7 +91,22 @@ for case_file in "$cases_dir"/*.txt; do
 
         payload=$(jq -cn --arg c "$command_under_test" \
             '{tool_name: "Bash", tool_input: {command: $c}}')
-        if [ -n "$(printf '%s' "$payload" | sh -c "$hook_cmd")" ]; then
+        if [ -n "$script_path" ]; then
+            out=$(printf '%s' "$payload" | bash "$script_path")
+        else
+            out=$(printf '%s' "$payload" | sh -c "$hook_cmd")
+        fi
+        rc=$?
+
+        # A no-match grep exits 1, which is the normal path. A hook that lets
+        # that escape aborts on every command it was not meant to block.
+        if [ "$rc" -ne 0 ]; then
+            suite_fail=$((suite_fail + 1))
+            printf '  FAIL exit=%-3s %s\n' "$rc" "$command_under_test"
+            continue
+        fi
+
+        if [ -n "$out" ]; then
             got=DENY
         else
             got=allow


### PR DESCRIPTION
## Problem

Two things in `~/.claude` were not properly managed by this repo.

**Hooks were inline JSON.** Every guard hook lived as a one-line shell command
embedded in `settings.json`. Quoting rules made them hard to read and harder to
change, they could not be tested in isolation, and a mistake in one only showed
up as a hook that silently stopped firing.

**Agent skills existed nowhere.** The global skills used by Claude Code and
Codex CLI were installed by hand, so a fresh `chezmoi apply` produced a machine
with none of them.

## Solution

### Hooks → scripts

Each guard moves into its own file under `dot_claude/hooks/`, with
`settings.json` referencing it by absolute path:

- `deny-recursive-rm.sh`
- `deny-destructive-push.sh`
- `deny-destructive-git.sh`
- `deny-interpreter-oneliners.sh`
- `todoist-sync-reminder.sh`

`scripts/test-claude-hooks.sh` now runs the case files against the scripts
themselves and verifies that `settings.json` actually points at each one, so an
unreferenced script fails the suite instead of going quiet. The extracted guards
exit 0 on unparseable input rather than blocking, and the `statusMessage`
fallback is gone now that no hook is inline. 113 cases pass.

### Agent skills

The skills are not committed. Each is either published in a remote repo
(installed with `npx skills`) or bundled inside its own CLI (installed with that
CLI's subcommand), and a tracked copy of a generated `SKILL.md` would be a
second copy to sync by hand. `run_onchange_after-install-agent-skills.sh.tmpl`
reinstalls whichever are missing and warns about any CLI a skill needs but
cannot find. `use-spark` is the exception — no upstream repo, no CLI subcommand
that ships it — so that copy is tracked and restored by chezmoi.

Skills bundled inside a CLI go stale silently: the CLI upgrades on its own
schedule while the `SKILL.md` on disk never changes, and the installer skips any
skill already present. `check-agent-skills.sh` runs at SessionStart and says so.
A `run_onchange_` script cannot do this, because it only runs when the script
itself changes.

The hook notifies and never reinstalls, since `<cli> skills install` overwrites
a file chezmoi tracks. `use-spark` is compared by version; the rest by whether
the CLI binary is newer than the `SKILL.md` it shipped, which clears itself on
reinstall and so needs no cached state. Remote-repo skills are excluded because
checking them needs the network, and a SessionStart hook has to stay offline
and fast.

## Verification

- `scripts/test-claude-hooks.sh` — 113 cases pass
- `check-agent-skills.sh` is silent on the current machine, and correctly
  detects both the version and mtime cases against a synthetic stale `HOME`
- `chezmoi status` clean after apply; `settings.json` validates
