### PR TITLE
feat(claude): pick the statusline renderer with CLAUDE_STATUSLINE

### DIFF
--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -1,39 +1,71 @@
 #!/usr/bin/env bash
-# Claude Code status line: user@host dir [branch] HH:MM ctx NN% (NNk/NNNk)
+# Claude Code status line dispatcher.
+#
+# CLAUDE_STATUSLINE picks the renderer:
+#   builtin (default) - the shell implementation below
+#   cship             - hand the payload to the cship binary
+#
+# Set it from fish with `set -Ux CLAUDE_STATUSLINE cship`; the universal
+# variable is exported, so this bash script sees it as a plain env var.
+# An unknown value, or a cship that is not installed, falls back to builtin
+# rather than leaving the status line blank.
 set -uo pipefail
 
 input=$(cat)
 
-IFS=$'\t' read -r current_dir used_pct used_tokens window_size <<<"$(
-  printf '%s' "$input" | jq -r '
-    [ (.workspace.current_dir // .cwd // "."),
-      (.context_window.used_percentage // -1),
-      (.context_window.total_input_tokens // 0),
-      (.context_window.context_window_size // 0)
-    ] | @tsv'
-)"
+# builtin: user@host dir [branch] HH:MM ctx NN% (NNk/NNNk)
+render_builtin() {
+  local current_dir used_pct used_tokens window_size branch ctx ctx_color host
 
-branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || echo 'no-git')
-[ -n "$branch" ] || branch='detached'
+  IFS=$'\t' read -r current_dir used_pct used_tokens window_size <<<"$(
+    printf '%s' "$input" | jq -r '
+      [ (.workspace.current_dir // .cwd // "."),
+        (.context_window.used_percentage // -1),
+        (.context_window.total_input_tokens // 0),
+        (.context_window.context_window_size // 0)
+      ] | @tsv'
+  )"
 
-# Context usage: green under 60%, yellow under 85%, red beyond.
-if [ "$used_pct" -lt 0 ]; then
-  ctx=$'\033[2mctx --\033[0m'
-else
-  if [ "$used_pct" -lt 60 ]; then
-    ctx_color=32
-  elif [ "$used_pct" -lt 85 ]; then
-    ctx_color=33
+  branch=$(git -C "$current_dir" branch --show-current 2>/dev/null || echo 'no-git')
+  [ -n "$branch" ] || branch='detached'
+
+  # Context usage: green under 60%, yellow under 85%, red beyond.
+  if [ "$used_pct" -lt 0 ]; then
+    ctx=$'\033[2mctx --\033[0m'
   else
-    ctx_color=31
+    if [ "$used_pct" -lt 60 ]; then
+      ctx_color=32
+    elif [ "$used_pct" -lt 85 ]; then
+      ctx_color=33
+    else
+      ctx_color=31
+    fi
+    ctx=$(printf '\033[%sm%s%% (%dk/%dk)\033[0m' \
+      "$ctx_color" "$used_pct" "$((used_tokens / 1000))" "$((window_size / 1000))")
   fi
-  ctx=$(printf '\033[%sm%s%% (%dk/%dk)\033[0m' \
-    "$ctx_color" "$used_pct" "$((used_tokens / 1000))" "$((window_size / 1000))")
-fi
 
-# `hostname` is absent on some machines (e.g. WSL images without net-tools).
-host=$(hostname -s 2>/dev/null || uname -n)
-host=${host%%.*}
+  # `hostname` is absent on some machines (e.g. WSL images without net-tools).
+  host=$(hostname -s 2>/dev/null || uname -n)
+  host=${host%%.*}
 
-printf '\033[2m%s@%s \033[36m%s\033[0m \033[33m[%s]\033[0m \033[2m%s\033[0m %s' \
-  "$(whoami)" "$host" "$(basename "$current_dir")" "$branch" "$(date +%H:%M)" "$ctx"
+  printf '\033[2m%s@%s \033[36m%s\033[0m \033[33m[%s]\033[0m \033[2m%s\033[0m %s' \
+    "$(whoami)" "$host" "$(basename "$current_dir")" "$branch" "$(date +%H:%M)" "$ctx"
+}
+
+# cship: configured by ~/.config/cship.toml, reads the same stdin payload.
+render_cship() {
+  printf '%s' "$input" | cship
+}
+
+case "${CLAUDE_STATUSLINE:-builtin}" in
+  cship)
+    if command -v cship >/dev/null 2>&1; then
+      render_cship
+    else
+      render_builtin
+    fi
+    ;;
+  *)
+    render_builtin
+    ;;
+esac

--- a/dot_config/cship.toml
+++ b/dot_config/cship.toml
@@ -1,0 +1,36 @@
+# cship — Claude Code statusline
+# Full config reference: https://cship.dev
+[cship]
+lines = [
+  "$directory$git_branch$git_status$python$nodejs$rust",
+  "$cship.model $cship.cost $cship.context_bar $cship.usage_limits"
+]
+
+[cship.model]
+symbol = "🤖 "
+style = "bold cyan"
+
+[cship.context_bar]
+width = 10
+style = "fg:#7dcfff"
+warn_threshold = 40.0
+warn_style = "fg:#e0af68"
+critical_threshold = 70.0
+critical_style = "bold fg:#f7768e"
+
+[cship.cost]
+symbol = "💰 "
+style = "fg:#a9b1d6"
+warn_threshold = 2.0
+warn_style = "fg:#e0af68"
+critical_threshold = 5.0
+critical_style = "bold fg:#f7768e"
+
+[cship.usage_limits]
+five_hour_format = "⌛ 5h {pct}% ({reset})"
+seven_day_format = "📅 7d {pct}% ({reset})"
+separator = " "
+warn_threshold = 60.0
+warn_style = "fg:#e0af68"
+critical_threshold = 80.0
+critical_style = "bold fg:#f7768e"


### PR DESCRIPTION
## Problem

The status line was switched to `cship` by pointing `settings.json` straight at
the binary. That swaps the renderer for every session at once, and the shell
implementation it replaced becomes recoverable only from git history — there is
no way to flip back for a single machine or a single session.

`~/.config/cship.toml` also existed only on this machine, so a fresh apply left
cship rendering with its built-in defaults.

## Solution

Keep `settings.json` pointing at `statusline.sh` and choose the renderer inside
the script, from `CLAUDE_STATUSLINE`:

- `builtin` (default) — the existing shell code, moved into a function unchanged
- `cship` — the same stdin payload handed to the binary

An unknown value, or a `cship` that is not on PATH, falls back to builtin: a
status line that fails is a blank line with no indication of why.

The variable is meant to be set with fish's `set -Ux`, which persists across
sessions and is exported to child processes, so this bash script reads it as a
plain environment variable. A Claude Code not launched from fish sees nothing
and gets the builtin renderer.

`dot_config/cship.toml` is tracked in its own commit so cship is configured on
a fresh apply.

## Verification

Exercised all five branches with a sample stdin payload — unset, `builtin`,
`cship`, an unknown value, and `cship` with PATH stripped. The builtin output is
byte-identical to before; the fallback paths all render builtin. `set -Ux` was
confirmed to reach a bash child, to persist into a new fish session, and to be
absent in a bash not descended from fish.