### PR TITLE
feat(claude): add ccstatusline as a statusline renderer

### DIFF
--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -4,6 +4,7 @@
 # CLAUDE_STATUSLINE picks the renderer:
 #   builtin (default) - the shell implementation below
 #   cship             - hand the payload to the cship binary
+#   ccstatusline      - hand the payload to the ccstatusline binary
 #
 # Set it from fish with `set -Ux CLAUDE_STATUSLINE cship`; the universal
 # variable is exported, so this bash script sees it as a plain env var.
@@ -52,15 +53,18 @@ render_builtin() {
     "$(whoami)" "$host" "$(basename "$current_dir")" "$branch" "$(date +%H:%M)" "$ctx"
 }
 
-# cship: configured by ~/.config/cship.toml, reads the same stdin payload.
-render_cship() {
-  printf '%s' "$input" | cship
+# External renderers take the same stdin payload and carry their own config:
+# cship reads ~/.config/cship.toml, ccstatusline ~/.config/ccstatusline/settings.json.
+render_external() {
+  printf '%s' "$input" | "$1"
 }
 
-case "${CLAUDE_STATUSLINE:-builtin}" in
-  cship)
-    if command -v cship >/dev/null 2>&1; then
-      render_cship
+renderer=${CLAUDE_STATUSLINE:-builtin}
+
+case "$renderer" in
+  cship | ccstatusline)
+    if command -v "$renderer" >/dev/null 2>&1; then
+      render_external "$renderer"
     else
       render_builtin
     fi

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -397,6 +397,7 @@
   },
   "statusLine": {
     "command": "bash \"$HOME/.claude/statusline.sh\"",
+    "refreshInterval": 30,
     "type": "command"
   },
   "tui": "fullscreen"

--- a/dot_config/ccstatusline/settings.json
+++ b/dot_config/ccstatusline/settings.json
@@ -1,0 +1,66 @@
+{
+  "version": 3,
+  "lines": [
+    [
+      {
+        "id": "1",
+        "type": "model",
+        "color": "cyan"
+      },
+      {
+        "id": "2",
+        "type": "separator"
+      },
+      {
+        "id": "3",
+        "type": "context-length",
+        "color": "brightBlack"
+      },
+      {
+        "id": "4",
+        "type": "separator"
+      },
+      {
+        "id": "5",
+        "type": "git-branch",
+        "color": "magenta"
+      },
+      {
+        "id": "6",
+        "type": "separator"
+      },
+      {
+        "id": "7",
+        "type": "git-changes",
+        "color": "yellow"
+      }
+    ],
+    [],
+    []
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 2,
+  "defaultPaddingSide": "both",
+  "inheritSeparatorColors": false,
+  "globalBold": false,
+  "gitCacheTtlSeconds": 5,
+  "minimalistMode": false,
+  "powerline": {
+    "enabled": false,
+    "separators": [
+      ""
+    ],
+    "separatorInvertBackground": [
+      false
+    ],
+    "startCaps": [],
+    "endCaps": [],
+    "autoAlign": false,
+    "continueThemeAcrossLines": false
+  },
+  "installation": {
+    "method": "pinned",
+    "installedVersion": "2.2.27"
+  }
+}


### PR DESCRIPTION
## Problem

The ccstatusline installer points `settings.json` straight at its own binary.
That undoes the dispatcher added in #3560: the renderer is fixed for every
session again, and the choice lives in a file the next installer will overwrite.

`~/.config/ccstatusline/settings.json` also existed only on this machine, so a
fresh apply would get the binary's stock layout instead of the configured one.

## Solution

Restore `statusLine.command` to `statusline.sh` and add `ccstatusline` as a
third value for `CLAUDE_STATUSLINE`, alongside `builtin` and `cship`.

The per-renderer function is gone. cship and ccstatusline differ only in the
name of the binary the payload is piped to, so one `render_external` taking that
name covers both, and a fourth renderer becomes a word in the case pattern.

## The two keys the installer added

Both were checked against the `statusLine` schema in the claude binary before
deciding, since an unrecognised key there is silently inert.

- `refreshInterval` — real (`v.number().min(1)`, seconds, "Re-run the status
  line command every N seconds in addition to event-driven updates"). Kept, but
  30 rather than the installer's 10: without it the status line only redraws on
  events, which freezes everything time-based (the builtin clock, cship's reset
  countdowns), but those readouts have minute resolution and ccstatusline costs
  ~180ms per run.
- `padding` — real, but its default is already 0 (`u?.padding ?? 0`, feeding
  Ink's `paddingX`). Writing `"padding": 0` changed nothing while looking like
  it did, so it is dropped.

## Verification

All six dispatcher branches exercised with a sample stdin payload: unset,
`builtin`, `cship`, `ccstatusline`, an unknown value, and `ccstatusline` with
PATH stripped. The last two fall back to builtin. shellcheck is clean, and the
real `~/.claude/statusline.sh` was driven through a fish session end to end.

Per-invocation cost, 5-run average: cship 37ms, builtin 54ms, ccstatusline
183ms.

## Note

The tracked ccstatusline config carries an `installation` block naming the
pinned version, so upgrading it will show up as chezmoi drift and needs a
`chezmoi add` to settle. The file has no separate config path that omits it.