### PR TITLE
fix(pwsh): make lint:pwsh report failures

### DIFF
--- a/docs/misc/for-windows/taskschd.msc/tasks/nvidia-smi-power-saving/register-nvidia-smi-power-saving.ps1
+++ b/docs/misc/for-windows/taskschd.msc/tasks/nvidia-smi-power-saving/register-nvidia-smi-power-saving.ps1
@@ -20,6 +20,10 @@
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost', '',
+    Justification = 'Interactive setup script; coloured status output is intentional.'
+)]
 param()
 
 Set-StrictMode -Version Latest

--- a/dot_config/try-rs/try-rs.ps1
+++ b/dot_config/try-rs/try-rs.ps1
@@ -1,5 +1,11 @@
 # try-rs integration for PowerShell
 function try-rs {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseApprovedVerbs', '',
+        Justification = 'Name must match the try-rs CLI it wraps.'
+    )]
+    param()
+
     # Captures the output of the binary (stdout) which is the "cd" or editor command
     # The TUI is rendered on stderr, so it doesn't interfere.
     $command = (try-rs.exe @args)

--- a/scripts/pssa.ps1
+++ b/scripts/pssa.ps1
@@ -1,9 +1,28 @@
-﻿Get-ChildItem -Recurse |
-    Where-Object {
-        $_.Name -match "\.ps1$" -and
-        $_.FullName -notmatch "\\node_modules\\"
-    } |
+#!/usr/bin/env pwsh
+# Lint every PowerShell script in the repository with PSScriptAnalyzer.
+# Exits non-zero when any diagnostic is reported, so lint failures break the task.
+
+if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+    Write-Output 'PSScriptAnalyzer is not installed.'
+    Write-Output 'Install it with: Install-Module -Name PSScriptAnalyzer -Scope CurrentUser'
+    exit 1
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$settings = Join-Path $repoRoot 'PSScriptAnalyzerSettings.psd1'
+
+$results = Get-ChildItem -Path $repoRoot -Recurse -File -Filter '*.ps1' |
+    Where-Object { $_.FullName -notmatch '[\\/]node_modules[\\/]' } |
     ForEach-Object {
-        Write-Output $_.FullName
-        Invoke-ScriptAnalyzer -Severity Warning $_.FullName
+        Invoke-ScriptAnalyzer -Path $_.FullName -Severity Warning -Settings $settings
     }
+
+if ($results) {
+    $results |
+        Format-Table -AutoSize RuleName, Severity, ScriptName, Line, Message |
+        Out-String -Width 200 |
+        Write-Output
+    exit 1
+}
+
+Write-Output 'PSScriptAnalyzer: no issues found.'


### PR DESCRIPTION
## Problem

`mise tasks run lint:pwsh` errored on every file (`Invoke-ScriptAnalyzer` not recognized) but still exited **0**, so the task counted as passing. Any real PSScriptAnalyzer finding would have been swallowed the same way.

Three further defects were hiding behind that:

- `PSScriptAnalyzerSettings.psd1` sat at the repo root but was never passed to `Invoke-ScriptAnalyzer`, so its `ExcludeRules` had no effect.
- The `node_modules` exclusion regex `"\\node_modules\\"` only matches Windows separators, so it never fires on Linux/macOS.
- The analyzer module itself is not installed anywhere by this repo, and the failure mode was an opaque wall of errors rather than an install hint.

## Solution

`scripts/pssa.ps1` now:

- exits 1 when any finding is reported, and exits 1 with an `Install-Module` hint when PSScriptAnalyzer is absent
- passes `-Settings PSScriptAnalyzerSettings.psd1`
- excludes `node_modules` on both path separators
- resolves the repo root from `$PSScriptRoot` instead of relying on the caller's cwd
- prints findings as a readable table instead of a column-wrapped dump

Turning on the non-zero exit surfaced two findings. Both are intentional and are suppressed inline with a justification rather than changed:

- `register-nvidia-smi-power-saving.ps1` — coloured `Write-Host` status output in an interactive setup script (`Write-Output` would drop the colour).
- `try-rs.ps1` — the function name must match the `try-rs` CLI it wraps, so the unapproved-verb rule cannot be satisfied by renaming. Verified `@args` still forwards correctly with the added empty `param()` block.

## Verification

```
clean tree      -> PSScriptAnalyzer: no issues found.   exit 0
seeded bad file -> 3 findings + task failed              exit 1
```

Note: PSScriptAnalyzer must be installed on the machine (`Install-Module -Name PSScriptAnalyzer -Scope CurrentUser`); the script now says so instead of failing obscurely.