### PR TITLE
feat(mise-task): implement lint:shell with shellcheck

### DIFF
--- a/.mise/tasks/git/empty-commits
+++ b/.mise/tasks/git/empty-commits
@@ -17,7 +17,7 @@ function count_commits(){
         wc -l
 }
 
-for i in $(seq 1 $(count_commits)); do
+for _ in $(seq 1 "$(count_commits)"); do
     git commit -nm "wip" --allow-empty
 done
 

--- a/.mise/tasks/lint/shell
+++ b/.mise/tasks/lint/shell
@@ -2,6 +2,6 @@
 #MISE description="Lint by shellcheck"
 #MISE hide=true
 
-# TODO: it
+bash scripts/shellcheck.sh
 
 # vim:ft=bash

--- a/dot_ad/lib/ad.sh
+++ b/dot_ad/lib/ad.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Helper functions for writing scripts to interact with ad
 
+# shellcheck source=/dev/null
 [ -e "$HOME/.profile" ] && source ~/.profile
 
 # Write a control message to ad.

--- a/private_dot_local/bin/executable_dotfyle
+++ b/private_dot_local/bin/executable_dotfyle
@@ -4,6 +4,9 @@ dir_name="neovim-configs"
 
 is_ignored() {
   found=false
+  # Upstream code. *"." already subsumes *"..", so the redundant pattern is
+  # harmless; left as-is to keep the diff against upstream empty.
+  # shellcheck disable=SC2221,SC2222
   case "$1" in
     *"." | *".." | *"*" | *".git")
       found=true

--- a/private_dot_local/bin/executable_re_boot
+++ b/private_dot_local/bin/executable_re_boot
@@ -7,7 +7,8 @@ if ! test "$(
   return
 fi
 
-read_prompt="Reboot?"
+# read_confirm runs as a separate process, so this has to be exported to reach it.
+export read_prompt="Reboot?"
 
 if read_confirm; then
   sync

--- a/private_dot_local/bin/executable_shut_down
+++ b/private_dot_local/bin/executable_shut_down
@@ -7,7 +7,8 @@ if ! test "$(
   return
 fi
 
-read_prompt="Shutdown?"
+# read_confirm runs as a separate process, so this has to be exported to reach it.
+export read_prompt="Shutdown?"
 
 if read_confirm; then
   sync

--- a/private_dot_local/bin/executable_vup
+++ b/private_dot_local/bin/executable_vup
@@ -244,7 +244,7 @@ other() {
 }
 
 w_only() {
-    if [ $(hostname) == $W_NAME ]; then
+    if [ "$(hostname)" = "$W_NAME" ]; then
         echo "This is Work-PC!!!"
         echo "Run Work-PC only update tasks"
         deps_update

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Lint every tracked shell script with shellcheck.
+#
+# chezmoi templates are skipped: Go template syntax is not valid shell.
+# fish scripts are skipped: shellcheck cannot parse fish.
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd -- "$repo_root"
+
+files=()
+while IFS= read -r file; do
+    case "$file" in
+    *.tmpl | *.fish) continue ;;
+    *.sh)
+        files+=("$file")
+        continue
+        ;;
+    esac
+
+    # Extensionless scripts (mise tasks, ~/.local/bin helpers) carry no hint in
+    # their name, so identify them by shebang instead.
+    IFS= read -r shebang <"$file" 2>/dev/null || continue
+    if [[ $shebang =~ ^#!.*[[:space:]/](sh|bash|dash|ksh)([[:space:]]|$) ]]; then
+        files+=("$file")
+    fi
+done < <(git ls-files)
+
+if ((${#files[@]} == 0)); then
+    echo "shellcheck: no shell scripts found" >&2
+    exit 1
+fi
+
+# --severity=warning mirrors the -Severity Warning used by scripts/pssa.ps1.
+shellcheck --severity=warning "${files[@]}"
+
+echo "shellcheck: no issues found in ${#files[@]} files."


### PR DESCRIPTION
## Context

Follow-up to #3566. That PR fixed `lint:pwsh` always exiting 0; this one audits the remaining lint tasks for the same class of defect.

## Audit result

The bash-level pass-through problem does **not** recur. All eight lint tasks are single-command scripts, so exit codes propagate, and the aggregate `lint` task correctly aborts on the first failure (verified with a seeded `exit 1` task). Every tool is installed and every task genuinely passes.

One task was a different flavour of the same problem, though:

```bash
# .mise/tasks/lint/shell
# TODO: it
```

`lint:shell` was a stub. `mise tasks run lint` reported success while shellcheck never ran on a single file — and nothing in CI covers shell scripts either. `format:shell` is a stub in the same way (see below).

## Solution

`scripts/shellcheck.sh`, invoked by the task, mirroring the existing `lint:pwsh` → `scripts/pssa.ps1` split.

File selection is shebang-aware rather than extension-only, because most shell scripts in this repo have no `.sh` suffix — the mise tasks, `dot_ad/bin/*`, and `private_dot_local/bin/*` would all have been missed. That takes coverage from 25 files to **106**. Skipped: chezmoi `*.tmpl` (Go template syntax is not valid shell) and fish (shellcheck cannot parse it). Severity threshold is `warning`, matching the `-Severity Warning` already used for PowerShell.

## Findings this surfaced

24 total at default severity, 8 at warning level. All 8 are fixed in the two preceding commits. One is a real bug:

`re_boot` and `shut_down` both set `read_prompt="Reboot?"` / `"Shutdown?"` and then call `read_confirm`. `read_confirm` is a **separate executable**, not a sourced function, so a non-exported variable never reaches it — both scripts silently fell back to the default prompt:

```
before:  prompt would be: Continue? [y/N]:
after:   prompt would be: Reboot? [y/N]:
```

So the confirmation prompt for a reboot and for a shutdown were indistinguishable. Fixed with `export`.

The rest are quoting and hygiene: an unquoted command substitution in `empty-commits` and in `vup` (also switched `==` to POSIX `=`), an unused loop variable, a `# shellcheck source=/dev/null` directive in `ad.sh`, and a suppression for a redundant `case` pattern in `dotfyle`, which is upstream code left byte-identical on purpose.

## Verification

```
clean tree      -> shellcheck: no issues found in 106 files.   exit 0
seeded bad file -> 2 findings + task failed                     exit 1
mise tasks run lint (full suite)                                exit 0
```

## Deliberately not in scope

`format:shell` is the same `# TODO: it` stub. Implementing it means running shfmt, which reformats **32 files with ~937 changed lines** — the repo mixes 2- and 4-space indentation against an `.editorconfig` that says 4. That is a large mechanical diff that would bury the fixes here, so it belongs in its own PR.