### PR TITLE
docs: pin the branch base, and stop trusting GitHub mergeable

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -36,6 +36,19 @@
 
 - **ワークフロー:** Explore → Plan → Code → Commit。feature ブランチを使う。
   並行作業には worktree を使う（`git worktree add ../project-<type>-<desc> <branch>`）。
+- **前提: 本人は基本 rebase merge を使う。** マージのたびに master 上の SHA が
+  変わる。squash も同じ。merge commit だけが SHA を保つ。下2つはこの前提から出ている。
+- **新しいブランチは master を最新にしてから切る。分岐元を省略しない:**
+  `git switch master; and git pull --ff-only; and git switch -c <name>`。
+  `git switch -c <name>` だけ実行すると**直前のブランチから枝分かれする**。
+  未マージのブランチの上に積むと、そのブランチがマージされた時点で SHA が変わり、
+  同じパッチを古い SHA で抱えたままになる。
+- **PR がマージ可能かを GitHub の `mergeable` で判断しない。**
+  `git cherry origin/master <branch>` を使い、**`-` が付いたコミットが無いこと**を見る。
+  `-` は「同等パッチが master に既にある」の意味で、rebase すると空コミットになり
+  GitHub が rebase merge を拒否する。**このとき GitHub は
+  `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` と表示するので当てにならない**
+  （2026-08-01 に発生。force push は禁止なので PR を出し直して対処した）。
 - **コミット:** Conventional Commits — `feat(scope): subject`、`fix`、`docs`、
   `perf`、`refactor`。
 - **PR:** 問題と解決策に焦点を当てる。co-authored-by やツールへの言及は入れない。


### PR DESCRIPTION
Follow-up to #3573 / #3574.

## What went wrong

`git switch -c <name>` without a base takes whatever HEAD happens to be. On
2026-08-01 that was an unmerged feature branch, so the follow-up branch carried
a commit that later landed on master under a **different SHA** — the owner
rebase-merges, which rewrites SHAs.

Rebasing that branch onto master would have produced an empty commit, so GitHub
refused the rebase merge. Force push is blocked in this environment, so the fix
cost a replacement PR (#3574) rather than a rebase in place.

## What GitHub did not tell us

Throughout the failure the API reported:

```
mergeable:        MERGEABLE
mergeStateStatus: CLEAN
```

Both were accurate for merge-commit and squash, and useless for rebase merge.
The only reliable check is:

```
git cherry origin/master <branch>
```

A leading `-` means an equivalent patch is already on master. Those are the
commits that go empty on rebase.

## Rules added

Three lines in `dot_claude/rules/general.md`, under Git:

1. **The premise** — the owner rebase-merges by default, so every merge rewrites
   SHAs. Merge commits are the only mode that preserves them. Without this
   stated, neither rule below reads as necessary.
2. **Refresh master and name the base** when creating a branch.
3. **Judge rebase-mergeability with `git cherry`**, not the GitHub field.

Rule 1 alone would not have prevented this — knowing the merge style does not
stop an omitted base argument. Rules 2 and 3 are what actually close it: one
prevents, one detects.

This PR was branched using rule 2 and checked with rule 3.