### PR TITLE
docs(claude): run plan-preview before exiting Plan Mode

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -76,3 +76,10 @@
   （`docs/plan/claude-permission-holes-20260731.md` §第5弾 を参照）。
   ファイルルールの中に `:*` を書くのは回避策ではなく明確なバリデーションエラー。
   `:*` の前方一致は `Bash(...)` にしか存在しない。
+- **Plan Mode: `ExitPlanMode` を呼ぶ前に `plan-preview` skill を走らせ、
+  計画本文に `Plan preview: <url>` の行を入れる。**
+  強制しているのは `reviewable-html-workbench` plugin 同梱の
+  `PreToolUse(ExitPlanMode)` hook であって、このルールではない。hook は
+  `Plan preview: <url>` か `Plan preview: unavailable (<理由>)` の行が無ければ deny する。
+  つまり先に走らせなければ deny → 生成 → 再試行で毎回1往復無駄になる。それだけの話。
+  `unavailable` は preview 生成が実際に失敗したときのためのもので、省略の手段ではない。


### PR DESCRIPTION
## 問題

`reviewable-html-workbench` plugin は `PreToolUse(ExitPlanMode)` の hook を同梱していて、計画本文に `Plan preview:` の行が無ければ ExitPlanMode を deny する。ここは既に動いている。

- 2026-08-02 に書かれた計画2件は両方とも preview URL を含む
- gate script に preview 行の無い計画を食わせると `permissionDecision: deny` が返る

足りていなかったのは順序だけ。計画を組み立てている最中に preview を作れという指示がどこにも無いので、実際の流れが `deny → 生成 → 再試行` になり、計画のたびに1往復無駄になっていた。

## 変更

`dot_claude/rules/general.md` の「Claude Code 自身の設定」節に1項目追加。

- 述べるのは順序だけ。**強制の主体は hook のままにする**ので、要件の写しが2箇所に増えて drift する余地を作らない
- `Plan preview: unavailable (<理由>)` は preview 生成が実際に失敗したときのためのもので、省略の手段ではない、と明記した。hook はどちらの行も受理するため、この区別は hook 側には書けない