### PR TITLE
feat(claude): add mattpocock-skills plugin, with grilling manual-only

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -4,6 +4,7 @@
   "enabledPlugins": {
     "cclens@cclens": true,
     "i-have-adhd@i-have-adhd": true,
+    "mattpocock-skills@claude-plugins-official": true,
     "obsidian@obsidian-skills": true,
     "reviewable-html-workbench@reviewable-html-workbench-local": true
   },

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -401,6 +401,7 @@
     ]
   },
   "skillOverrides": {
+    "mattpocock-skills:grilling": "user-invocable-only",
     "officecli": "off"
   },
   "statusLine": {


### PR DESCRIPTION
## 問題

`mattpocock-skills` プラグインは41スキルを持ち込む。そのうち **17スキルは `disable-model-invocation` を持たず、会話の流れでモデル側の判断により自動発火する。**

自動発火する17のうち16はコードを相手にする（`tdd` `code-review` `diagnosing-bugs` `prototype` `research` など）。**対人スキルは `productivity/grilling` の1つだけ**で、これは本文に "Interview me **relentlessly**" と "Do not act on it until I confirm we have reached a shared understanding" を持つ。

つまり、こちらが依頼していないのに詰問形式の対話が始まり、しかも合意に達するまで打ち切る手順が用意されていない。`~/.claude/CLAUDE.md` の停止ルール（「考えたい」「まだ決めていない」と言われたら質問を止める / 停止は終了ではない）と正面から衝突する。

## 解決策

プラグインを有効化した上で、`grilling` だけ `skillOverrides` で入口を絞る。

```json
"skillOverrides": {
  "mattpocock-skills:grilling": "user-invocable-only"
}
```

`off` ではなく `user-invocable-only` を選んだ理由: 問題は「詰問が**勝手に始まる**こと」であって「詰問が存在すること」ではない。`off` にすると意図的に使いたいときにも使えなくなる。`user-invocable-only` なら `/grilling` と打鍵したときだけ走り、**分岐が1つの判断ルール**（打鍵したときだけ）になる。

これで自動発火する対人スキルはゼロになる。`grill-me` `grill-with-docs` `batch-grill-me` `triage` `to-tickets` `wayfinder` などは元から `disable-model-invocation: true` のため対応不要。

## 検証

- `skillOverrides` はバイナリ（2.1.220）に実在し、値は `on` / `name-only` / `user-invocable-only` / `off` の4種
- `disabledSkills` / `disableAllSkills` はバイナリに存在しない（採用せず）
- `chezmoi apply` 後、`chezmoi status` は空（drift なし）