### PR TITLE
refactor(cargo): call mimikun.scripts instead of duplicating it

### DIFF
--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -603,83 +603,52 @@ if ($res) {
 }
 
 # alias cargo packages
-if ($IsLinux) {
-    $tmp = Join-Path -Path $env:HOME -ChildPath ".mimikun-pkglists"
-    $cargo_packages = Join-Path -Path $tmp -ChildPath "linux_cargo_packages.txt"
+#
+# These are thin wrappers. The implementation lives in mimikun/mimikun.scripts
+# as TypeScript run by bun, so Linux and Windows share one copy. The package
+# list path (linux_* vs windows_*) is resolved there, not here.
+$MimikunScriptsDir = if ($env:MIMIKUN_SCRIPTS_DIR) {
+    $env:MIMIKUN_SCRIPTS_DIR
 } else {
-    $tmp = Join-Path -Path $env:USERPROFILE -ChildPath ".mimikun-pkglists"
-    $cargo_packages = Join-Path -Path $tmp -ChildPath "windows_cargo_packages.txt"
+    Join-Path -Path $HOME -ChildPath "scripts"
 }
 
-function Invoke-ExistsCmd() {
-    Param($cmdName)
-    Get-Command -Name $cmdName > $null 2>&1
-    $result = $?
-    return $result
+function Invoke-MimikunCargoScript() {
+    Param(
+        [Parameter(Mandatory)][string]$Script,
+        [string[]]$ScriptArgs = @()
+    )
+    $path = Join-Path -Path $MimikunScriptsDir -ChildPath $Script
+    if (-not (Test-Path -Path $path)) {
+        Write-Error "mimikun.scripts not found at $MimikunScriptsDir - clone it, or set MIMIKUN_SCRIPTS_DIR"
+        return
+    }
+    bun run $path @ScriptArgs
 }
 
 function Invoke-GenerateCargoPackageLists() {
-    cargo install-update --list |
-    Select-Object -Skip 3 |
-    ForEach-Object { $_.Split(" ")[0] } |
-    Where-Object { $_ -ne "" } |
-    Out-File -FilePath $cargo_packages -Encoding utf8
+    Invoke-MimikunCargoScript -Script "src/generate/cargo-package-list.ts"
 }
 
 Set-Alias -Name generate_cargo_package_list -Value Invoke-GenerateCargoPackageLists
 Set-Alias -Name genecapa -Value Invoke-GenerateCargoPackageLists
 
 function Invoke-InstallCargoPackages() {
-    Get-Content -Path $cargo_packages |
-    ForEach-Object {
-        $pkg = $_
-        $cond = Invoke-ExistsCmd $pkg
-        if (-not $cond) {
-            Write-Output "$pkg is not found"
-            pueue add -- "cargo install $pkg"
-        }
-    }
+    Invoke-MimikunCargoScript -Script "src/install/cargo-packages.ts"
     Invoke-GenerateCargoPackageLists
 }
 
 Set-Alias -Name install_cargo_packages -Value Invoke-InstallCargoPackages
 Set-Alias -Name instacapa -Value Invoke-InstallCargoPackages
 
-function Get-NeedUpdateCargoPackages() {
-    $tmp = cargo install-update --list |
-    Select-Object -Skip 2
-    $need_update_pkgs = $tmp -split "`n" |
-    ForEach-Object {
-        if ($_ -match "^\s*Package\s+Installed\s+Latest\s+Needs update\s*$") {
-            return
-        }
-        if ($_ -match "^\s*(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*$" -and $matches[4] -eq "Yes") {
-            [PSCustomObject]@{
-                Package      = $matches[1]
-                Installed    = $matches[2]
-                Latest       = $matches[3]
-                NeedsUpdate  = $matches[4]
-            }
-        }
-    }
-    return $need_update_pkgs
-}
-
+# Builds in the foreground rather than going through pueue.
 function Invoke-UpdateCargoPackages() {
-    Get-NeedUpdateCargoPackages | ForEach-Object {
-        $pkgs = $_.Package
-        Write-Output "Update: $pkgs"
-        cargo install $pkgs
-    }
+    Invoke-MimikunCargoScript -Script "src/update/cargo-packages.ts" -ScriptArgs @("--no-pueue")
     Invoke-GenerateCargoPackageLists
 }
 
 function Invoke-PueueUpdateCargoPackages() {
-    Get-NeedUpdateCargoPackages | ForEach-Object {
-        $pkgs = $_.Package
-        Write-Output "Update: $pkgs"
-        pueue add -- "cargo install $pkgs"
-    }
+    Invoke-MimikunCargoScript -Script "src/update/cargo-packages.ts"
     Invoke-GenerateCargoPackageLists
 }
 

--- a/private_dot_local/bin/executable_generate_cargo_package_list
+++ b/private_dot_local/bin/executable_generate_cargo_package_list
@@ -1,8 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+set -euo pipefail
 
-cargo install-update --list |
-    tail -n +4 |
-    sed -e "s/ /\t/g" |
-    cut -f 1 |
-    sed "/^\$/d" |
-    sort >"$HOME/.mimikun-pkglists/linux_cargo_packages.txt"
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+exec bun run "$SCRIPTS_DIR/src/generate/cargo-package-list.ts" "$@"

--- a/private_dot_local/bin/executable_install_cargo_packages
+++ b/private_dot_local/bin/executable_install_cargo_packages
@@ -1,19 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+#
+# --serial keeps one cargo build running at a time, which is what the
+# hand-rolled `pueue add --after "$task_id"` chain here used to do.
+set -euo pipefail
 
-function existsCmd() {
-    type -a "$1" >/dev/null 2>&1
-}
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-task_id=$(pueue add -p -- "echo TEMP_TASK")
-
-while read -r line; do
-    if ! existsCmd "$line"; then
-        echo "$line is not found"
-
-        if [ "$1" == "--no-pueue" ]; then
-            cargo install "$line"
-        else
-            task_id=$(pueue add --after "$task_id" -p -- "cargo install $line")
-        fi
-    fi
-done <"$HOME/.mimikun-pkglists/linux_cargo_packages.txt"
+exec bun run "$SCRIPTS_DIR/src/install/cargo-packages.ts" --serial "$@"

--- a/private_dot_local/bin/executable_pueue_update_cargo_packages
+++ b/private_dot_local/bin/executable_pueue_update_cargo_packages
@@ -1,8 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+#
+# Unlike update_cargo_packages this does not pass --serial: every build is
+# enqueued at once and pueue's own parallelism decides how many run.
+set -euo pipefail
 
-cargo_outdated_pkgs=$(cargo install-update -l | grep "Yes" | cut -d " " -f 1)
-echo "Update these packages:"
-echo "$cargo_outdated_pkgs"
-for i in $cargo_outdated_pkgs; do
-  pueue add -- "cargo install $i"
-done
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+exec bun run "$SCRIPTS_DIR/src/update/cargo-packages.ts" "$@"

--- a/private_dot_local/bin/executable_update_cargo_packages
+++ b/private_dot_local/bin/executable_update_cargo_packages
@@ -1,17 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+#
+# --serial keeps one cargo build running at a time, which is what the
+# hand-rolled `pueue add --after "$task_id"` chain here used to do. Pass
+# --no-pueue to build in the foreground instead.
+set -euo pipefail
 
-cargo_outdated_pkgs=$(cargo install-update -l | grep "Yes" | cut -d " " -f 1)
-echo "Update these packages:"
-echo "$cargo_outdated_pkgs"
-
-if [ "$1" == "--no-pueue" ]; then
-    for i in $cargo_outdated_pkgs; do
-        cargo install "$i"
-    done
-else
-    task_id=$(pueue add -p -- "echo start")
-
-    for i in $cargo_outdated_pkgs; do
-        task_id=$(pueue add --after "$task_id" -p -- "cargo install $i")
-    done
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
 fi
+
+exec bun run "$SCRIPTS_DIR/src/update/cargo-packages.ts" --serial "$@"


### PR DESCRIPTION
## 問題

cargo の生成 / 導入 / 更新のロジックが、このリポジトリに**2重に**存在していた。

- `private_dot_local/bin/executable_*_cargo_*`（Linux 用、`~/.local/bin` に配備）
- `dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl` 内の関数（Windows と pwsh 用）

両者は互いにも、`mimikun/mimikun.scripts` 側とも食い違っていた。**書式の差だけではない。**

- bash 側はロケール依存の `sort`、`~/scripts` 側は `LC_ALL=C sort`。**同じファイルに書く2つの実装が並び順で食い違う。** PowerShell 側はソートすらしない
- どちらも `cargo install-update --list` の出力を空白で分割してパッケージ名を取っていた。Latest 列に pre-release の注記（`v0.9.9 (v0.10.0-rc.6 available)`）が入る行を誤読する
- どちらも末尾の `<pkg> contains removed executables ...` という注記行をパッケージ名として拾っていた

## 解決

両方を **TypeScript 実装への薄いラッパー**に置き換えた。Linux と Windows が同じコードを走らせる。パッケージリストのパス、Yes/No のパース、tabiew / rustowl の HACK は1箇所に集約される。

**意図のある差は潰していない。**

| コマンド | 渡すフラグ | 理由 |
|---|---|---|
| `install_cargo_packages` | `--serial` | 手書きの `--after "$task_id"` 連鎖と同じく、ビルドを1本ずつ流す |
| `update_cargo_packages` | `--serial` | 同上 |
| `pueue_update_cargo_packages` | なし | 元から全部まとめて積む |
| `Invoke-UpdateCargoPackages` | `--no-pueue` | 元から前面で `cargo install` する |

**PowerShell のエイリアス7つはすべて維持**（`genecapa` / `instacapa` / `upcapa` / `generate_cargo_package_list` / `install_cargo_packages` / `update_cargo_packages` / `pueue_update_cargo_packages`）。更新系が末尾でリストを再生成する挙動もそのまま。

リポジトリの場所は `${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}` で解決し、**見つからない場合は黙って何もせず終わるのではなく、明示的なメッセージを出して失敗する。**

## 検証

pwsh は Linux でも動くので、PowerShell 側も実機で確認した。

- テンプレート展開後、PowerShell パーサで構文エラーなし（820行）
- cargo セクションを dot-source し、パス解決・引数の受け渡し（`--serial` 含む）・エイリアス7つの定義を確認
- bash シム4本の dry-run が、直列/並列の使い分けを含めて期待どおり
- repo 不在時、bash 側は終了コード1、PowerShell 側は `Write-Error` で明示的に失敗
- `chezmoi apply` 後、`~/.local/bin` の配備済みコマンドとして実行を確認。drift なし

## 前提

**このリポジトリが `mimikun/mimikun.scripts` に依存するようになる。** 新しいマシンでは、cargo 系コマンドを使う前に同リポジトリを `$HOME/scripts` に clone しておく必要がある（または `MIMIKUN_SCRIPTS_DIR` を設定）。bun も必要だが、profile には既に `Invoke-BunUpgrade` があり前提として成立している。

依存先: mimikun/mimikun.scripts#6