### PR TITLE
refactor(generate): call mimikun.scripts for package lists

### DIFF
--- a/private_dot_local/bin/executable_generate_cargo_package_list
+++ b/private_dot_local/bin/executable_generate_cargo_package_list
@@ -10,4 +10,4 @@ if [[ ! -d "$SCRIPTS_DIR" ]]; then
   exit 1
 fi
 
-exec bun run "$SCRIPTS_DIR/src/generate/cargo-package-list.ts" "$@"
+exec bun run "$SCRIPTS_DIR/src/generate/package-lists.ts" cargo

--- a/private_dot_local/bin/executable_generate_pip_package_list
+++ b/private_dot_local/bin/executable_generate_pip_package_list
@@ -1,8 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+set -euo pipefail
 
-pip freeze |
-    sed \
-        -e "s/=.*//g" \
-        -e "s/ @.*//g" |
-    sort > \
-        "$HOME/.mimikun-pkglists/linux_pip_packages.txt"
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+exec bun run "$SCRIPTS_DIR/src/generate/package-lists.ts" pip

--- a/private_dot_local/bin/executable_generate_pipx_package_list
+++ b/private_dot_local/bin/executable_generate_pipx_package_list
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+set -euo pipefail
 
-pipx list --short |
-    cut -d " " -f 1 |
-    sort > \
-        "$HOME/.mimikun-pkglists/linux_pipx_packages.txt"
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+exec bun run "$SCRIPTS_DIR/src/generate/package-lists.ts" pipx

--- a/private_dot_local/bin/executable_generate_uv_tool_list
+++ b/private_dot_local/bin/executable_generate_uv_tool_list
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+set -euo pipefail
 
-uv tool list |
-    grep "v[0-9]" |
-    sed -e "s/\s.*//g" |
-    sort >"$HOME/.mimikun-pkglists/linux_uv_tools.txt"
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
+
+exec bun run "$SCRIPTS_DIR/src/generate/package-lists.ts" uv


### PR DESCRIPTION
## 問題

`generate_pip_package_list` / `generate_pipx_package_list` / `generate_uv_tool_list` はそれぞれ、`mimikun.scripts` 側が1つの表で扱うようになったパイプラインを再実装していた。

さらに、これらは `LC_ALL=C` 無しの `sort` を使っていた。**同じファイルを書く `~/scripts` 側とは並び順が食い違う。**（cargo で見つけたのと同じ乖離）

## 解決

`src/generate/package-lists.ts` を呼ぶシムに置き換えた。生成対象は引数で指定する。

`generate_cargo_package_list` も一緒に移した。移管先の `cargo-package-list.ts` が同じ表に吸収されたため。

| コマンド | 呼び出し |
|---|---|
| `generate_cargo_package_list` | `package-lists.ts cargo` |
| `generate_pip_package_list` | `package-lists.ts pip` |
| `generate_pipx_package_list` | `package-lists.ts pipx` |
| `generate_uv_tool_list` | `package-lists.ts uv` |

## 検証

`chezmoi apply` 後、`generate_pipx_package_list` を実走し 42件が生成されることを確認。移管元では9リストすべてが旧パイプラインとバイト一致。

なお移管先で、**コマンドが無い／失敗したときにリストが空に切り詰められるバグ**も直っている。これらのシムを使う場合も同様に、失敗時は既存の内容が保たれる。

依存先: mimikun/mimikun.scripts#8