### PR TITLE
refactor(install): call mimikun.scripts for package installs

### DIFF
--- a/private_dot_local/bin/executable_install_cargo_packages
+++ b/private_dot_local/bin/executable_install_cargo_packages
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
-# so the same code runs here and on Windows. See that repo's AGENTS.md.
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript.
+# See that repo's AGENTS.md.
 #
-# --serial keeps one cargo build running at a time, which is what the
-# hand-rolled `pueue add --after "$task_id"` chain here used to do.
+# --serial installs one package at a time, which is what the hand-rolled
+# `pueue add --after "$task_id"` chain here used to do.
 set -euo pipefail
 
 SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
@@ -13,4 +13,4 @@ if [[ ! -d "$SCRIPTS_DIR" ]]; then
   exit 1
 fi
 
-exec bun run "$SCRIPTS_DIR/src/install/cargo-packages.ts" --serial "$@"
+exec bun run "$SCRIPTS_DIR/src/install/packages.ts" cargo --serial "$@"

--- a/private_dot_local/bin/executable_install_gh_extensions
+++ b/private_dot_local/bin/executable_install_gh_extensions
@@ -1,13 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript.
+# See that repo's AGENTS.md.
+#
+# --serial installs one package at a time, which is what the hand-rolled
+# `pueue add --after "$task_id"` chain here used to do.
+set -euo pipefail
 
-task_id=$(pueue add -p -- "echo TEMP_TASK")
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-while read -r line; do
-    echo "Install: $line"
-
-    if [ "$1" == "--no-pueue" ]; then
-        gh extension install "$line"
-    else
-        task_id=$(pueue add --after "$task_id" -p -- "gh extension install $line")
-    fi
-done <"$HOME/.mimikun-pkglists/gh_extension_list.txt"
+exec bun run "$SCRIPTS_DIR/src/install/packages.ts" gh-extension --serial "$@"

--- a/private_dot_local/bin/executable_install_pip_packages
+++ b/private_dot_local/bin/executable_install_pip_packages
@@ -1,26 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript.
+# See that repo's AGENTS.md.
+#
+# --serial installs one package at a time, which is what the hand-rolled
+# `pueue add --after "$task_id"` chain here used to do.
+set -euo pipefail
 
-task_id=$(pueue add -p -- "echo TEMP_TASK")
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-while read -r line; do
-    case "$line" in
-    "thefuck")
-        echo "Install specify version thefuck"
-
-        if [ "$1" == "--no-pueue" ]; then
-            pip install 'thefuck @ git+https://github.com/nvbn/thefuck@62e0767c5069aeee176b0fe3459068b7703aaa26'
-        else
-            task_id=$(pueue add --after "$task_id" -p -- "pip install 'thefuck @ git+https://github.com/nvbn/thefuck@62e0767c5069aeee176b0fe3459068b7703aaa26'")
-        fi
-        ;;
-    *)
-        echo "Install: $line"
-
-        if [ "$1" == "--no-pueue" ]; then
-            pip install "$line"
-        else
-            task_id=$(pueue add --after "$task_id" -p -- "pip install $line")
-        fi
-        ;;
-    esac
-done <"$HOME/.mimikun-pkglists/linux_pip_packages.txt"
+exec bun run "$SCRIPTS_DIR/src/install/packages.ts" pip --serial "$@"

--- a/private_dot_local/bin/executable_install_pipx_packages
+++ b/private_dot_local/bin/executable_install_pipx_packages
@@ -1,13 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript.
+# See that repo's AGENTS.md.
+#
+# --serial installs one package at a time, which is what the hand-rolled
+# `pueue add --after "$task_id"` chain here used to do.
+set -euo pipefail
 
-task_id=$(pueue add -p -- "echo TEMP_TASK")
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-while read -r line; do
-    echo "Install: $line"
-
-    if [ "$1" == "--no-pueue" ]; then
-        pipx install "$line"
-    else
-        task_id=$(pueue add --after "$task_id" -p -- "pipx install $line")
-    fi
-done <"$HOME/.mimikun-pkglists/linux_pipx_packages.txt"
+exec bun run "$SCRIPTS_DIR/src/install/packages.ts" pipx --serial "$@"

--- a/private_dot_local/bin/executable_install_uv_tools
+++ b/private_dot_local/bin/executable_install_uv_tools
@@ -1,13 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript.
+# See that repo's AGENTS.md.
+#
+# --serial installs one package at a time, which is what the hand-rolled
+# `pueue add --after "$task_id"` chain here used to do.
+set -euo pipefail
 
-task_id=$(pueue add -p -- "echo TEMP_TASK")
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-while read -r line; do
-    echo "Install: $line"
-
-    if [ "$1" == "--no-pueue" ]; then
-        uv tool install "$line"
-    else
-        task_id=$(pueue add --after "$task_id" -p -- "uv tool install $line")
-    fi
-done <"$HOME/.mimikun-pkglists/linux_uv_tools.txt"
+exec bun run "$SCRIPTS_DIR/src/install/packages.ts" uv --serial "$@"


### PR DESCRIPTION
## 問題

`install_cargo_packages` / `install_gh_extensions` / `install_pip_packages` / `install_pipx_packages` / `install_uv_tools` は、いずれも「リストを読んで1行ずつ導入コマンドを積む」同じループの写しだった。移管先ではこれが1つの表になっている。

## 解決

`src/install/packages.ts` を呼ぶシムに置き換えた。各シムはリスト名と `--serial` を渡す。`--serial` は、これらが手書きで組んでいた `pueue add --after "$task_id"` の連鎖を再現する（先頭のダミー `echo TEMP_TASK` は不要になった）。

| コマンド | 呼び出し |
|---|---|
| `install_cargo_packages` | `packages.ts cargo --serial` |
| `install_gh_extensions` | `packages.ts gh-extension --serial` |
| `install_pip_packages` | `packages.ts pip --serial` |
| `install_pipx_packages` | `packages.ts pipx --serial` |
| `install_uv_tools` | `packages.ts uv --serial` |

## 検証

`chezmoi apply` 後、`install_pipx_packages --dry-run` が42件を `--after` 連鎖付きで出すことを確認。移管元では旧ループとの比較で1100件中1100件が一致。

移管先では、**パッケージマネージャが無いリストをスキップする**ようになり、動かない導入コマンドを積まなくなっている。

依存先: mimikun/mimikun.scripts#9