### PR TITLE
refactor(bin): replace update_pnpm, turn compose updater into a shim

### DIFF
--- a/.mise/tasks/update/chezmoi
+++ b/.mise/tasks/update/chezmoi
@@ -94,7 +94,6 @@ chezmoi add ~/.local/bin/update_docker_compose
 chezmoi add ~/.local/bin/update_fish_completions
 chezmoi add ~/.local/bin/update_mise
 chezmoi add ~/.local/bin/update_pip_packages
-chezmoi add ~/.local/bin/update_pnpm
 chezmoi add ~/.local/bin/update_poetry
 chezmoi add ~/.local/bin/vup
 chezmoi add ~/.local/bin/wsl-open

--- a/maskfile.md
+++ b/maskfile.md
@@ -327,7 +327,6 @@ chezmoi add ~/.local/bin/update_docker_compose
 chezmoi add ~/.local/bin/update_fish_completions
 chezmoi add ~/.local/bin/update_mise
 chezmoi add ~/.local/bin/update_pip_packages
-chezmoi add ~/.local/bin/update_pnpm
 chezmoi add ~/.local/bin/update_poetry
 chezmoi add ~/.local/bin/vup
 chezmoi add ~/.local/bin/wsl-open

--- a/private_dot_local/bin/README.md
+++ b/private_dot_local/bin/README.md
@@ -22,7 +22,6 @@
     - update_bat_fish_completion
     - update_helix_fish_completion
 - [utilities](https://github.com/mimikun/utilities)
-    - update_pnpm
     - update_poetry
     - generate_cargo_package_list
     - git-amend-commit

--- a/private_dot_local/bin/executable_update_docker_compose
+++ b/private_dot_local/bin/executable_update_docker_compose
@@ -1,18 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+#
+# --no-pueue by default: the system-wide destination needs sudo, which cannot
+# prompt from inside a pueue task. Pass --dry-run to see what would be fetched.
+#
+# On machines running Docker Desktop this does nothing -- Docker Desktop ships
+# the compose plugin itself and keeps every cli-plugins entry as a symlink into
+# its own tree. Machines running Docker Engine still need this.
+set -euo pipefail
 
-TEMPSTR=$(docker-compose version --short)
-OLD_VERSION="v$TEMPSTR"
-VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
-DESTINATIONS=("$HOME/.docker/cli-plugins/docker-compose" "/usr/local/lib/docker/cli-plugins/docker-compose")
-
-if test "$OLD_VERSION" != "$VERSION"; then
-  echo "Update found!"
-  curl -L "https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o "${DESTINATIONS[0]}"
-  sudo cp "${DESTINATIONS[0]}" "${DESTINATIONS[1]}"
-  # $HOME/.docker/cli-plugins/docker-compose
-  chmod 755 "${DESTINATIONS[0]}"
-  # /usr/local/lib/docker/cli-plugins/docker-compose
-  sudo chmod 755 "${DESTINATIONS[1]}"
-else
-  echo "No update required."
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
 fi
+
+exec bun run "$SCRIPTS_DIR/src/update/docker-compose.ts" --no-pueue "$@"

--- a/private_dot_local/bin/executable_update_pnpm
+++ b/private_dot_local/bin/executable_update_pnpm
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-curl -fsSL https://get.pnpm.io/install.sh | sh -

--- a/private_dot_local/bin/executable_vup
+++ b/private_dot_local/bin/executable_vup
@@ -107,8 +107,8 @@ use_pueue() {
   echo "flyctl version upgrade"
   pueue add -- "flyctl version upgrade"
 
-  echo "update_pnpm"
-  pueue add -- "update_pnpm"
+  echo "pnpm self-update"
+  pueue add -- "pnpm self-update"
 
   echo "update mise tools"
   pvim_task_id=$(pueue add -p --after "$mise_task_id" -- "update_mise paleovim-master --use-pueue")
@@ -185,8 +185,8 @@ no_pueue() {
   echo "flyctl version upgrade"
   flyctl version upgrade
 
-  echo "update_pnpm"
-  update_pnpm
+  echo "pnpm self-update"
+  pnpm self-update
 
   echo "update mise tools"
   update_mise paleovim-master


### PR DESCRIPTION
Follows mimikun/mimikun.scripts#12, which holds the implementation.

## `update_pnpm` — deleted

The whole script was:

```sh
curl -fsSL https://get.pnpm.io/install.sh | sh -
```

pnpm 11.18.0 has `pnpm self-update`, so `vup` calls that directly and the script goes away.

## `update_docker_compose` — now a thin shim

Same shape as the cargo and fish-completion shims. `vup` still calls it by name, so `vup` itself only changed where it used to say `update_pnpm`.

The implementation now **skips on machines running Docker Desktop**. On this machine Docker Desktop keeps every `cli-plugins` entry as a symlink into its own tree — buildx, scout, mcp, model, sandbox and 13 others. Only `docker-compose` was a real 31 MB file, because this script had downloaded over it. All three copies were `5.3.1`, so it was adding nothing, and the moment GitHub publishes ahead of Docker Desktop it would start a tug of war over a managed file using `sudo`.

Machines running Docker Engine still need it, so the check is at run time (`~/.docker/desktop` exists — no daemon and no WSL required) rather than the script being deleted.

Verified through the deployed shim:

```
$ update_docker_compose
Docker Desktop is installed, which ships and updates the compose plugin
itself. Nothing to do.
```

## Merge order

Merge mimikun/mimikun.scripts#12 first — the shim reads `$HOME/scripts`, so the TypeScript file has to be on master before this lands.