### PR TITLE
refactor(bin): turn update_mise into a shim, drop three subcommands

### DIFF
--- a/private_dot_local/bin/executable_update_mise
+++ b/private_dot_local/bin/executable_update_mise
@@ -1,174 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows. See that repo's AGENTS.md.
+#
+# This used to have four subcommands. Three of them did what `mise upgrade`
+# already does -- run `mise upgrade --dry-run` and watch it offer to bump both
+# vim@latest and zig@master. What mise cannot notice is a `ref:` pin whose
+# commit moved, because the version string stays "ref:master" no matter how far
+# upstream goes, so the tool never shows up in `mise outdated`. That is the
+# only job left, and it needs no subcommand.
+#
+# Pass a tool name to limit it (currently only paleovim-master), --no-pueue to
+# rebuild in the foreground, or --dry-run to see what would be queued.
+set -euo pipefail
 
-#=======================
-# 変数定義
-#=======================
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
+fi
 
-readonly PRODUCT_VERSION="0.7.0"
-PRODUCT_NAME="$(basename "${0}")"
-readonly MISE_ZIG_BINDIR="$MISE_DATA_DIR/installs/zig"
-readonly BIN_ZIG="bin/zig"
-
-#=======================
-# 関数定義
-#=======================
-
-# 使い方、ヘルプメッセージ
-usage() {
-    cat <<EOF
-$PRODUCT_NAME(bash)
-Update mise-tools
-
-Usage:
-    $PRODUCT_NAME <COMMAND> <SUBCOMMANDS>
-
-Commands:
-    paleovim-master                Run update mise paleovim master
-    paleovim-latest                Run update mise paleovim latest
-    zig-master                     Run update mise zig master
-    zig-latest                     Run update mise zig latest
-
-Command options:
-    --use-pueue                    Run command with pueue
-
-Options:
-    --version, -v, version         print $PRODUCT_NAME version
-    --help, -h, help               print this help
-EOF
-}
-
-# バージョン情報出力
-version() {
-    echo "$PRODUCT_NAME(bash) v$PRODUCT_VERSION"
-}
-
-function _paleovim_master() {
-    local commit_hash_file
-    commit_hash_file="$HOME/.cache/paleovim-master-commit-hash.txt"
-    local commit_hash
-    commit_hash=$(cat "$commit_hash_file")
-    local new_commit_hash
-    new_commit_hash=$(git ls-remote --heads --tags https://github.com/vim/vim.git | grep refs/heads/master | cut -f 1)
-
-    if [ "$commit_hash" != "$new_commit_hash" ]; then
-        echo "paleovim (latest)master found!"
-        echo "$new_commit_hash" >"$commit_hash_file"
-        if [ "$opt" == "--use-pueue" ]; then
-            task_id=$(pueue add -p -- "mise uninstall vim@ref:master")
-            pueue add --after "$task_id" -- "mise install vim@ref:master"
-        else
-            mise uninstall vim@ref:master
-            mise install vim@ref:master
-        fi
-    else
-        echo "paleovim (latest)master is already installed"
-        echo "commit hash: $commit_hash"
-    fi
-}
-
-function _paleovim_latest() {
-    local version
-    version=$(mise current vim)
-    local new_version
-    new_version=$(mise latest vim)
-
-    if [ "$version" != "$new_version" ]; then
-        echo "paleovim latest version ( $new_version) found!"
-        if [ "$opt" == "--use-pueue" ]; then
-            task_id=$(pueue add -p -- "mise uninstall vim@latest")
-            pueue add --after "$task_id" -- "mise install vim@latest"
-        else
-            mise uninstall "vim@latest"
-            mise install "vim@latest"
-        fi
-    else
-        echo "paleovim latest version ( $new_version ) is already installed"
-    fi
-}
-
-function _zig_master() {
-    local zig_version_file
-    zig_version_file="$HOME/.cache/zig-master-version.txt"
-    local zig_version
-    zig_version=$(cat "$zig_version_file")
-    local new_zig_version
-    new_zig_version=$(curl -sSL https://ziglang.org/download/index.json | jq .master.version --raw-output)
-
-    if [ "$zig_version" != "$new_zig_version" ]; then
-        echo "zig (latest)master found!"
-        echo "$new_zig_version" >"$zig_version_file"
-        if [ "$opt" == "--use-pueue" ]; then
-            task_id=$(pueue add -p -- "mise uninstall zig@ref:master")
-            pueue add --after "$task_id" -- "mise install zig@ref:master"
-        else
-            mise uninstall zig@ref:master
-            mise install zig@ref:master
-        fi
-    else
-        echo "zig (latest)master is already installed"
-        echo "version: $zig_version"
-    fi
-}
-
-function _zig_latest() {
-    local version
-    version=$("$MISE_ZIG_BINDIR/latest/$BIN_ZIG" version)
-    local new_version
-    new_version=$(mise latest zig)
-
-    if [ "$version" != "$new_version" ]; then
-        echo "zig (latest)master found!"
-        if [ "$opt" == "--use-pueue" ]; then
-            task_id=$(pueue add -p -- "mise uninstall zig@$version")
-            pueue add --after "$task_id" -- "mise install zig@$new_version"
-        else
-            mise uninstall "zig@$version"
-            mise install "zig@$new_version"
-        fi
-    else
-        echo "zig (latest)master ( $version ) is already installed"
-    fi
-}
-
-#=======================
-# メイン処理
-#=======================
-while (("$#")); do
-    case "$1" in
-    -h | --help | help)
-        usage
-        exit 1
-        ;;
-    -v | --version | version)
-        version
-        exit 1
-        ;;
-    paleovim-master | paleovim-latest | zig-master | zig-latest)
-        cmd=$1
-        opt=$2
-        shift
-        ;;
-    *)
-        break
-        ;;
-    esac
-done
-
-case $cmd in
-paleovim-master)
-    _paleovim_master "$opt"
-    ;;
-paleovim-latest)
-    _paleovim_latest "$opt"
-    ;;
-zig-master)
-    _zig_master "$opt"
-    ;;
-zig-latest)
-    _zig_latest "$opt"
-    ;;
-*)
-    usage
-    exit 1
-    ;;
-esac
+exec bun run "$SCRIPTS_DIR/src/update/mise-refs.ts" "$@"

--- a/private_dot_local/bin/executable_vup
+++ b/private_dot_local/bin/executable_vup
@@ -110,10 +110,10 @@ use_pueue() {
   echo "pnpm self-update"
   pueue add -- "pnpm self-update"
 
-  echo "update mise tools"
-  pvim_task_id=$(pueue add -p --after "$mise_task_id" -- "update_mise paleovim-master --use-pueue")
-  pueue add --after "$pvim_task_id" -- "update_mise paleovim-latest --use-pueue"
-  pueue add --after "$mise_task_id" -- "update_mise zig-master --use-pueue"
+  # `mise upgrade` above already covers vim@latest and zig@master. The one pin
+  # it cannot refresh is vim@ref:master, which is all update_mise does now.
+  echo "update mise ref-pinned tools"
+  update_mise --after "$mise_task_id"
 
   echo "update neovim managed by bob"
   bob_task_id=$(pueue add -p -- "bob use latest")
@@ -188,10 +188,8 @@ no_pueue() {
   echo "pnpm self-update"
   pnpm self-update
 
-  echo "update mise tools"
-  update_mise paleovim-master
-  update_mise paleovim-latest
-  update_mise zig-master
+  echo "update mise ref-pinned tools"
+  update_mise --no-pueue
 
   echo "update neovim managed by bob"
   bob use latest


### PR DESCRIPTION
Follows mimikun/mimikun.scripts#13, which holds the implementation.

`update_mise` was 174 lines and four subcommands. Three of them did what `mise upgrade` already does, and `vup` queues `mise upgrade` one line earlier:

```
$ mise upgrade --dry-run
Would uninstall vim@9.2.0894
Would uninstall zig@0.17.0-dev.1516+8a4b5424d
Would install vim@9.2.0901
Would install zig@0.17.0-dev.1525+91c6d8a09
```

The one thing mise cannot notice is a `ref:` pin whose commit moved — the version string stays `ref:master` however far upstream goes, so the tool never turns up in `mise outdated`. That is all this does now, and it needs no subcommand.

## Three bugs, none of which ever failed

| subcommand | what was wrong |
|---|---|
| `zig-master` | Queued `mise uninstall zig@ref:master`, but the config pins `zig = ["master", ...]`, so it hit nothing. The same block existed inline in `mimikun.scripts/vup.sh` spelled `zig@master` — **that copy was the correct one.** |
| `paleovim-latest` | Compared `mise current vim` with `mise latest vim`. Two vim versions are configured, so `mise current` prints both (`ref:master 9.2.0894`) and never equals a bare `9.2.0901`. **It rebuilt vim from source on every run.** |
| `zig-latest` | Unreachable from either caller, and read `$MISE_DATA_DIR/installs/zig/...` with `MISE_DATA_DIR` unset. |

## Verified through the deployed shim

```
$ update_mise --dry-run
paleovim-master moved: c28515b9... -> 1050666c...
pueue add -- mise uninstall 'vim@ref:master'
pueue add --after #1 -- mise install 'vim@ref:master'

$ update_mise zig-master --dry-run
error: unknown tool: zig-master (have paleovim-master)
```

The generated command set for `paleovim-master` is byte-identical to the old script's, checked against a recording `pueue` stub.

## Merge order

Merge mimikun/mimikun.scripts#13 first — the shim reads `$HOME/scripts`, so the TypeScript file has to be on master before this lands.