### PR TITLE
fix(powershell): point the mimikun.scripts shims at files that exist

### DIFF
--- a/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -613,7 +613,7 @@ $MimikunScriptsDir = if ($env:MIMIKUN_SCRIPTS_DIR) {
     Join-Path -Path $HOME -ChildPath "scripts"
 }
 
-function Invoke-MimikunCargoScript() {
+function Invoke-MimikunScript() {
     Param(
         [Parameter(Mandatory)][string]$Script,
         [string[]]$ScriptArgs = @()
@@ -627,14 +627,14 @@ function Invoke-MimikunCargoScript() {
 }
 
 function Invoke-GenerateCargoPackageLists() {
-    Invoke-MimikunCargoScript -Script "src/generate/cargo-package-list.ts"
+    Invoke-MimikunScript -Script "src/generate/package-lists.ts" -ScriptArgs @("cargo")
 }
 
 Set-Alias -Name generate_cargo_package_list -Value Invoke-GenerateCargoPackageLists
 Set-Alias -Name genecapa -Value Invoke-GenerateCargoPackageLists
 
 function Invoke-InstallCargoPackages() {
-    Invoke-MimikunCargoScript -Script "src/install/cargo-packages.ts"
+    Invoke-MimikunScript -Script "src/install/packages.ts" -ScriptArgs @("cargo")
     Invoke-GenerateCargoPackageLists
 }
 
@@ -643,12 +643,12 @@ Set-Alias -Name instacapa -Value Invoke-InstallCargoPackages
 
 # Builds in the foreground rather than going through pueue.
 function Invoke-UpdateCargoPackages() {
-    Invoke-MimikunCargoScript -Script "src/update/cargo-packages.ts" -ScriptArgs @("--no-pueue")
+    Invoke-MimikunScript -Script "src/update/cargo-packages.ts" -ScriptArgs @("--no-pueue")
     Invoke-GenerateCargoPackageLists
 }
 
 function Invoke-PueueUpdateCargoPackages() {
-    Invoke-MimikunCargoScript -Script "src/update/cargo-packages.ts"
+    Invoke-MimikunScript -Script "src/update/cargo-packages.ts"
     Invoke-GenerateCargoPackageLists
 }
 
@@ -672,13 +672,7 @@ if ($isMSWindows) {
 
 # alias editorconfig Invoke-GenerateEditorConfig
 function Invoke-GenerateEditorConfig() {
-    Get-Item -Path .\.editorconfig -ErrorAction Ignore
-    $res = $?
-    if (!$res) {
-        Write-Output ".editorconfig not exist."
-        Write-Output "Creating .editorconfig."
-        Copy-Item -Path $env:USERPROFILE\.editorconfig-template -Destination .\.editorconfig
-    }
+    Invoke-MimikunScript -Script "src/misc/editorconfig.ts"
 }
 Set-Alias -Name editorconfig Invoke-GenerateEditorConfig
 

--- a/private_dot_local/bin/executable_editorconfig
+++ b/private_dot_local/bin/executable_editorconfig
@@ -1,8 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Thin shim. The implementation lives in mimikun/mimikun.scripts as TypeScript,
+# so the same code runs here and on Windows -- this and the PowerShell
+# Invoke-GenerateEditorConfig were the same five lines twice.
+# See that repo's AGENTS.md.
+set -euo pipefail
 
-# Generate editorconfig
-if test ! -e .editorconfig; then
-    echo ".editorconfig not exist."
-    echo "Creating .editorconfig."
-    cp "$HOME"/.editorconfig-template ./.editorconfig
+SCRIPTS_DIR="${MIMIKUN_SCRIPTS_DIR:-$HOME/scripts}"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  echo "mimikun.scripts not found at $SCRIPTS_DIR" >&2
+  echo "clone it, or set MIMIKUN_SCRIPTS_DIR" >&2
+  exit 1
 fi
+
+exec bun run "$SCRIPTS_DIR/src/misc/editorconfig.ts" "$@"


### PR DESCRIPTION
Follows mimikun/mimikun.scripts#17. Replaces #3597, which was branched from a local master that still carried `docs(claude): tell the agent how to make a printable A4 page` under its pre-rebase SHA, so `git cherry` marked it `-` and rebase merge would have replayed it as an empty commit. Same tree, one commit on top of master.

## Two broken paths on Windows

`Invoke-MimikunCargoScript` referred to two scripts by their **pre-rename** names:

| profile said | actual file |
|---|---|
| `src/generate/cargo-package-list.ts` | `src/generate/package-lists.ts` + `cargo` |
| `src/install/cargo-packages.ts` | `src/install/packages.ts` + `cargo` |
| `src/update/cargo-packages.ts` | OK |

So `generate_cargo_package_list` and `install_cargo_packages` had been failing on Windows. Both files also take the list name as an argument now, which the profile was not passing.

The failure was easy to miss twice over: it only happens on Windows, and the message is

```
mimikun.scripts not found at ...
```

which reads as a missing **repository** rather than a missing file inside one.

## editorconfig

Becomes a shim over `src/misc/editorconfig.ts` on both sides. The bash and PowerShell copies were the same five lines, differing only in `cp` versus `Copy-Item` and `$HOME` versus `$env:USERPROFILE`.

## Also

`Invoke-MimikunCargoScript` → `Invoke-MimikunScript`, since it no longer runs only cargo things (6 call sites).

## Verification

```
$ chezmoi execute-template < ...ps1.tmpl > profile.ps1     # 814 lines
$ pwsh -NoProfile -Command '[Parser]::ParseFile(...)'      # PowerShell 構文 OK
```

All four `-Script` paths now resolve against `~/scripts`. The bash shim was exercised end to end on this machine.

## Merge order

Merge mimikun/mimikun.scripts#17 first — both shims read `$HOME/scripts`.