### PR TITLE
docs(claude): define which forge is authoritative per repository

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -64,6 +64,19 @@
   `perf`、`refactor`。
 - **PR:** 問題と解決策に焦点を当てる。co-authored-by やツールへの言及は入れない。
 
+### リモートの使い分け（2026-08-03 に定義）
+
+**主かミラーかは `origin` が指す先で決まる。** リモート名の並び順や登録数では決めない。
+
+- **既定は GitHub が主、Codeberg はミラー。push は GitHub だけでよい。**
+  Codeberg へは本人が手で push する（Codeberg 側のミラー機能が使えないため）。
+  **AI は Codeberg へ push しない。** PR も GitHub に出す
+- **例外: `origin` が Codeberg を指すリポジトリだけは Codeberg が主。**
+  そのリポジトリでは PR も Codeberg（`berg` CLI）に出す
+- **迷ったら `git remote get-url origin` を見る。** これが唯一の判定材料
+- **ミラー側が遅れていても勝手に追いつかせない。** 本人が手で push する運用なので、
+  差があるのは異常ではない
+
 ## 🤖 Claude Code 自身の設定
 
 - 実際に読まれる設定は `~/.claude/settings.json` で、chezmoi 管理下にある


### PR DESCRIPTION
## 問題

GitHub と Codeberg の両方をリモート登録しているリポジトリがあるのに、どちらへ push すべきかが決まっていなかった。Codeberg 側のミラー機能が使えず手で push している運用のため、エージェントが勝手に push すると本人の運用と衝突する。

判定材料が無いことによる実害も出た。Codeberg/master が GitHub より古いのを見て「取り残されている」と報告したが、**あれは正常な状態**だった。

## 解決策

`rules/general.md` の 🌳 Git とコミット に「リモートの使い分け」を追記する。

- **既定は GitHub が主、Codeberg は手 push のミラー。** AI は Codeberg へ push しない。PR も GitHub に出す
- **例外: `origin` が Codeberg を指すリポジトリだけは Codeberg が主。** PR も Codeberg に出す
- 判定は `git remote get-url origin` だけで行う。リモートの登録順や名前では決めない
- ミラー側が遅れていても勝手に追いつかせない

## 経緯

この13行は #3596 の2件目のコミットだった。#3596 は、並行していた別ブランチが同じパッチを cherry-pick した状態でマージされたため、GitHub に「マージ済み」と判定されて自動クローズされた。1件目（🖨 紙に印刷する資料）は複製経由で master に載っているが、**2件目は取り残されていた。** master から切り直して載せ直す。