### PR TITLE
docs(claude): git rules for agents working alongside another session

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -60,6 +60,12 @@
   GitHub が rebase merge を拒否する。**このとき GitHub は
   `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` と表示するので当てにならない**
   （2026-08-01 に発生。force push は禁止なので PR を出し直して対処した）。
+- **マージ後、コミットが全部 master に載ったか数える。**
+  `git log origin/master --oneline` で自分のコミットを確認する。
+  **GitHub は、同等のパッチが別経路で master に載ると PR を「マージ済み」として
+  自動クローズすることがあり、残りのコミットは黙って取り残される。**
+  上の rebase 拒否と違い**エラーが出ないので、数えない限り気づけない**
+  （2026-08-03 に発生。PR に積んだ2件のうち1件が消え、切り直して出し直した）。
 - **コミット:** Conventional Commits — `feat(scope): subject`、`fix`、`docs`、
   `perf`、`refactor`。
 - **PR:** 問題と解決策に焦点を当てる。co-authored-by やツールへの言及は入れない。
@@ -72,6 +78,14 @@
 ```
 git worktree add ../<repo>-<desc> <branch>   # 作業 → commit → push
 git worktree remove ../<repo>-<desc>         # 終わったら必ず消す
+```
+
+**`<branch>` が他の worktree でチェックアウト済みだと `worktree add` は失敗する。**
+master はほぼ常にこれに当たるので、master で作業するときは次の形にする。
+
+```
+git worktree add --detach ../<repo>-<desc> master
+git push origin HEAD:master
 ```
 
 - **chezmoi は `-S` で worktree を指す:** `chezmoi add -S <worktree> <対象ファイル>`。

--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -46,7 +46,7 @@
 ## 🌳 Git とコミット
 
 - **ワークフロー:** Explore → Plan → Code → Commit。feature ブランチを使う。
-  並行作業には worktree を使う（`git worktree add ../project-<type>-<desc> <branch>`）。
+  作業場所は下の「エージェントは worktree で作業する」に従う。
 - **前提: 本人は基本 rebase merge を使う。** マージのたびに master 上の SHA が
   変わる。squash も同じ。merge commit だけが SHA を保つ。下2つはこの前提から出ている。
 - **新しいブランチは master を最新にしてから切る。分岐元を省略しない:**
@@ -63,6 +63,25 @@
 - **コミット:** Conventional Commits — `feat(scope): subject`、`fix`、`docs`、
   `perf`、`refactor`。
 - **PR:** 問題と解決策に焦点を当てる。co-authored-by やツールへの言及は入れない。
+
+### エージェントは worktree で作業する（2026-08-03 に決定）
+
+**リポジトリに書き込むときは、必ず新規 worktree を切る。既存の作業ディレクトリは
+本人専用。** 判定は不要 — 全リポジトリ、常に。
+
+```
+git worktree add ../<repo>-<desc> <branch>   # 作業 → commit → push
+git worktree remove ../<repo>-<desc>         # 終わったら必ず消す
+```
+
+- **chezmoi は `-S` で worktree を指す:** `chezmoi add -S <worktree> <対象ファイル>`。
+  実体ファイルを編集して `chezmoi add` すると、**共有の source ディレクトリに書く**ので
+  worktree の意味が消える
+- **例外は1つだけ: ビルド成果物や依存を持つリポジトリ**（`node_modules`、`venv` など）。
+  worktree ごとに再構築が要るので、本人に確認してから決める
+- **理由:** 2026-08-03、別セッションが同じリポジトリでブランチを切り替えている最中に
+  `chezmoi add` が相手の作業ツリーへ紛れ込んだ。**共有資源を無くせば原理的に起きない。**
+  「書き込む前に確認する」型の対策では、同時書き込み自体は残る
 
 ## 🤖 Claude Code 自身の設定
 


### PR DESCRIPTION
`rules/general.md` に、エージェントの git 運用ルールを3件追加する。いずれも 2026-08-03 に実際に起きた事故から。

## 1. エージェントは worktree で作業する

**問題:** 2つのセッションが同じリポジトリを同時に扱い、片方がブランチを切り替えている最中に、もう片方の `chezmoi add` が**相手の作業ツリーへ紛れ込んだ**。作業ディレクトリが共有資源になっているのが原因で、これは今後も起きる。

**解決策:**

- **リポジトリに書き込むときは必ず新規 worktree を切る。既存の作業ディレクトリは本人専用**
- 判定は不要。全リポジトリ、常に
- **chezmoi は `-S` で worktree を指す。** 実体ファイルを編集して `chezmoi add` すると共有の source ディレクトリに書くため、worktree の意味が消える
- 例外は1つだけ: ビルド成果物や依存を持つリポジトリ

「書き込む前にブランチを確認する」ではない理由: 確認は**気づくだけで防いでいない**。同時書き込み自体は残る。共有資源を無くせば原理的に起きない。

あわせて、ワークフローの箇条書きにあった「並行作業には worktree を使う」を削除した（同じことが2箇所に書かれる状態を避けるため）。

## 2. master で作業するときは `--detach`

**問題:** `git worktree add <path> <branch>` は、そのブランチが他の worktree でチェックアウト済みだと失敗する。master はほぼ常にこれに当たるため、1のルールが master でそのまま使えない（実際に転んだ）。

**解決策:** `--detach` で切り、`git push origin HEAD:master` で戻す形を明記した。

## 3. マージ後、コミットが全部載ったか数える

**問題:** 並行していた別ブランチが同じパッチを cherry-pick した状態でマージされ、GitHub が PR #3596 を「マージ済み」と判定して自動クローズした。**積んでいた2件のうち1件が黙って取り残された**（#3599 で出し直し）。

cherry-pick に限らず、rebase・手動適用・別 PR での重複でも同じことが起きる。

**解決策:** マージ後に `git log origin/master --oneline` で自分のコミットを数える。既存の「rebase merge が拒否される」ルールと違い、**こちらはエラーが出ないので数えない限り気づけない。**

---

記録は `mimikun.agent-system` の `records/P16-session-shoutotsu.md`（next-check 2026-08-17）。