### PR TITLE
revert(fish): take UV_PYTHON back out of the unused copy

### DIFF
--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -4,10 +4,6 @@ set -x LC_ALL "en_US.UTF-8"
 set -x GHQ_ROOT $HOME/ghq
 set -x GHQ_SELECTOR fzf
 set -x PIPENV_VENV_IN_PROJECT 1
-# Which interpreter `uv tool install` builds on when nothing asks for one.
-# Without this uv picks its only managed install, which is how tools ended up
-# scattered across 3.10 to 3.13. A project's .python-version still wins.
-set -x UV_PYTHON "3.12"
 set -x TODAY (date +"%Y/%m/%d")
 set -x TZ "Asia/Tokyo"
 


### PR DESCRIPTION
`dotfiles#3612` で `dot_config/fish/config.fish.tmpl` に `UV_PYTHON` を足したが、**このツリーは配備されない。** `.chezmoiignore.tmpl` の 42行目 `.config/fish/**` が条件分岐の外にあり、全マシンで ignore されている。

生きている fish 設定は `mimikun/mimikun.fish-config`（`~/.config/fish` にチェックアウト）で、`config/env_paths.fish` が `set -gx` を持っている。設定はそちらへ入れ直した（`mimikun.fish-config#5`）。

`dotfiles#3612` のもう一方の変更（`linux_uv_tools.txt`）は生きているので、そのまま。

**この repo の `dot_config/fish/` ツリー全体が死んでいる**（21.5KB の tmpl + completions + functions）。消すかどうかは、1件ずつ生きた対応物を確認してから別途。