### PR TITLE
chore(renovate): stop bumping pinned mise lua/python

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,17 @@
   "extends": [
     "config:recommended",
     "github>aquaproj/aqua-renovate-config:file#2.13.0(aqua/.*\\.ya?ml)"
+  ],
+  "packageRules": [
+    {
+      // These are deliberately floating pins: mise resolves "5.1" / "3.12" to the
+      // newest release in that series. Renovate rewrites them to a concrete
+      // version, which defeats the point. Both were reverted before (1f81d111,
+      // 75e6a1ed). Note the mise manager only updates the FIRST entry of an
+      // array, so this also covers python's list.
+      "matchManagers": ["mise"],
+      "matchDepNames": ["lua", "python"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Problem

`dot_config/mise/config.toml` pins `lua = "5.1"` and `python = "3.12"` as *floating*
pins — mise resolves them to the newest release in that series. Renovate's mise
manager picks the file up (default pattern `**/{,.}mise/config{,.*}.toml`) and
rewrites them to concrete versions, which defeats the point.

This has happened twice and been reverted both times:

| Renovate commit | change | revert |
| --- | --- | --- |
| `1a47dc67` | python `"3.12"` -> `"3.14.0"` | `75e6a1ed` |
| `9d5755a0` | lua `"5.1"` -> `"5.5.0"` | `1f81d111` |

## Solution

Add a `packageRules` entry disabling the `mise` manager for `lua` and `python`.

`allowedVersions` was rejected: capping the range still makes Renovate rewrite
`"3.12"` to a concrete `"3.12.x"`, so the floating pin is lost either way.
`enabled: false` is the only option that preserves it.

`matchDepNames` is used rather than `matchPackageNames` — the latter's fallback to
depName is slated for deprecation and emits a WARN.

Only these two tools are affected today: the mise manager updates just the *first*
entry of an array, and every other value in the file is `latest` / `master` /
`ref:master`, which it cannot parse as a version.

Validated with `renovate-config-validator` (config validated successfully, no
deprecation warnings).