### PR TITLE
docs(rules): require a fully qualified ref when branching off a detached worktree

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -88,6 +88,12 @@ git worktree add --detach ../<repo>-<desc> master
 git push origin HEAD:master
 ```
 
+- **detached HEAD から新しいブランチを作るときは ref を完全修飾する:**
+  `git push origin HEAD:refs/heads/<name>`。`HEAD:<name>` の短い形は
+  **既存ブランチにしか当たらず**、新規だと
+  `You must fully qualify the ref.` で落ちる。すぐ上の `HEAD:master` が
+  通るのは master が既にあるからで、**例外のほうが既定に見えている**
+  （2026-08-07 に踏んだ）。
 - **chezmoi は `-S` で worktree を指す:** `chezmoi add -S <worktree> <対象ファイル>`。
   実体ファイルを編集して `chezmoi add` すると、**共有の source ディレクトリに書く**ので
   worktree の意味が消える


### PR DESCRIPTION
## 問題

`rules/general.md` の「エージェントは worktree で作業する」節が示している push の例は 1つだけ。

```
git worktree add --detach ../<repo>-<desc> master
git push origin HEAD:master
```

これが通るのは **master が既に存在するから**で、同じ形で新規ブランチを作ろうとすると落ちる。

```
$ git push origin HEAD:docs/mason-nvim-dap
error: The <src> part of the refspec is a commit object.
       You must fully qualify the ref.
```

detached worktree から新規ブランチを切るのは、`--detach` 手順を使うたびに毎回起きる。つまり**節に載っている唯一の例が例外のケースで、普通に起きるほうが未文書**だった。

## 解決策

`--detach` のコードブロック直後に箇条書きを1つ足し、`git push origin HEAD:refs/heads/<name>` を書く。短い形が既存ブランチにしか当たらないこと、すぐ上の `HEAD:master` が通る理由も添えた（そこを読んで真似すると落ちるため）。

## 検証

```
$ chezmoi -S ~/.local/share/chezmoi-rules-detached-ref diff ~/.claude/rules/general.md
```

追加6行のみ、他に差分なし。実際にこのルール通り `HEAD:refs/heads/docs/worktree-detached-ref` で push している。

マージ後に `chezmoi apply` が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)