### PR TITLE
Block commits made under the wrong git identity

### DIFF
--- a/dot_config/git/hooks/executable_author-identity
+++ b/dot_config/git/hooks/executable_author-identity
@@ -1,0 +1,38 @@
+#!/bin/bash
+# git pre-commit hook: refuse a commit attributed to an identity that is not mine.
+#
+# Agent runtimes have overridden GIT_AUTHOR_EMAIL / GIT_COMMITTER_EMAIL, producing
+# commits attributed to the wrong person. An env override never shows up in
+# `git config user.email`, so checking config is useless here -- `git var *_IDENT`
+# is the value that actually reflects it.
+#
+# Wired up in ~/.gitconfig as [hook "author-identity"], so it applies to every
+# repository on this machine without a per-repo install.
+#
+# Denied addresses are stored as SHA-256 digests because this repository is public.
+#
+# Bypass: GIT_ALLOW_ANY_IDENTITY=1 git commit ...   (or `git commit --no-verify`)
+
+set -euo pipefail
+
+if [[ "${GIT_ALLOW_ANY_IDENTITY:-0}" == "1" ]]; then
+  exit 0
+fi
+
+# The Claude account address behind the mis-attributed commits of 2026-08-07.
+denied_digests=(
+  "80481824b07faaca9d28153e346f4fc3601c7bb8702e4513ec1f18c53c21d8fe"
+)
+
+for var in GIT_AUTHOR_IDENT GIT_COMMITTER_IDENT; do
+  email="$(git var "$var" | sed -n 's/.*<\(.*\)>.*/\1/p' | tr '[:upper:]' '[:lower:]')"
+  digest="$(printf '%s' "$email" | sha256sum | cut -d ' ' -f 1)"
+
+  for denied in "${denied_digests[@]}"; do
+    if [[ "$digest" == "$denied" ]]; then
+      echo "git: $var is <$email>, which is on the denied-identity list." >&2
+      echo "git: fix the identity before committing, or set GIT_ALLOW_ANY_IDENTITY=1." >&2
+      exit 1
+    fi
+  done
+done

--- a/dot_config/hk/config.pkl
+++ b/dot_config/hk/config.pkl
@@ -1,5 +1,5 @@
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -131,8 +131,12 @@
 [hook "hk-post-rewrite"]
 	command = test \"${HK:-1}\" = \"0\" || hk run post-rewrite --from-hook \"$@\"
 	event = post-rewrite
+# No repository here has an hk.pkl, and `--from-hook` makes hk exit 0 silently in
+# that case -- so the steps in ~/.config/hk/config.pkl never ran. Dropping the
+# flag is what makes the global config take effect. `hk install --global` will
+# put `--from-hook` back if it is ever re-run.
 [hook "hk-pre-commit"]
-	command = test \"${HK:-1}\" = \"0\" || hk run pre-commit --from-hook \"$@\"
+	command = test \"${HK:-1}\" = \"0\" || hk run pre-commit \"$@\"
 	event = pre-commit
 [hook "hk-pre-push"]
 	command = test \"${HK:-1}\" = \"0\" || hk run pre-push --from-hook \"$@\"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -103,6 +103,16 @@
 	diffFilter = delta --color-only
 
 # =============================================================================
+# git hooks (mine)
+# =============================================================================
+
+# Refuse commits attributed to an identity that is not mine. Config-based hooks
+# are global, so this needs no per-repo install. See the script for the why.
+[hook "author-identity"]
+	command = {{ .chezmoi.homeDir }}/.config/git/hooks/author-identity
+	event = pre-commit
+
+# =============================================================================
 # git hooks (by hk.jdx.dev)
 # =============================================================================
 

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -141,9 +141,14 @@
 [hook "hk-pre-push"]
 	command = test \"${HK:-1}\" = \"0\" || hk run pre-push --from-hook \"$@\"
 	event = pre-push
+# `git rebase --root` passes no UPSTREAM (and passes `--root` through), but
+# `hk run pre-rebase` requires one, so every rooted rebase is refused. No
+# pre-rebase steps are configured in ~/.config/hk/config.pkl, so this hook can
+# only break things. `hk install --global` will drop the `enabled` line if re-run.
 [hook "hk-pre-rebase"]
 	command = test \"${HK:-1}\" = \"0\" || hk run pre-rebase --from-hook \"$@\"
 	event = pre-rebase
+	enabled = false
 [hook "hk-prepare-commit-msg"]
 	command = test \"${HK:-1}\" = \"0\" || hk run prepare-commit-msg --from-hook \"$@\"
 	event = prepare-commit-msg


### PR DESCRIPTION
## Problem

On 2026-08-07, five commits across three repositories were authored and committed
under an address that is not mine. Git config was not the cause -- `user.email`
resolved to `git@mimikun.dev` everywhere, no repo-local or worktree-local `user.*`
was set, and there is no `includeIf` branch. The commit-time environment was
overriding the identity, which means fixing config cannot prevent a recurrence.

A second problem surfaced while verifying the fix: the `gitleaks` step in
`~/.config/hk/config.pkl` had never run on a single commit. The global git hook
calls `hk run pre-commit --from-hook`, and `--from-hook` makes hk exit 0 silently
when the repository has no `hk.pkl`. No repository on this machine has one.

## Solution

- **`.config/git/hooks/author-identity`** — a pre-commit hook that reads
  `git var GIT_AUTHOR_IDENT` and `GIT_COMMITTER_IDENT`. Env overrides never appear
  in `git config user.email`, so checking config would miss exactly the failure
  that happened; `git var` does reflect them. Registered in `~/.gitconfig` as a
  config-based hook (`hook.author-identity.*`, git 2.54+), so it applies to every
  repository without a per-repo install.

  Denied addresses are stored as SHA-256 digests, since this repository is public.
  A denylist rather than an allowlist: `.gitconfig.d/work.inc.tmpl` resolves a
  different address on work machines, so a `@mimikun.dev`-only allowlist would
  reject every commit there.

- **Drop `--from-hook` from `hook.hk-pre-commit.command`** so the steps in the
  global hk config actually execute.

- **Disable `hook.hk-pre-rebase`.** `git rebase --root` passes no UPSTREAM, which
  `hk run pre-rebase` requires, so every rooted rebase was refused and needed
  `HK=0`. No pre-rebase steps are configured, so the hook had nothing to do.

- **Bump the `Config.pkl` amends to 1.54.0** to match the installed hk. 1.44.2 was
  not a deliberate pin; nothing tracks pkl package URLs.

## Verification

Run in throwaway repositories:

| Case | Result |
| --- | --- |
| `GIT_AUTHOR_EMAIL=<denied> git commit` | rejected |
| `GIT_COMMITTER_EMAIL=<denied> git commit` | rejected |
| mixed-case variant of the address | rejected (normalized before hashing) |
| normal commit | passes |
| `GIT_ALLOW_ANY_IDENTITY=1` / `--no-verify` | bypasses, as intended |
| staged PEM private key | rejected by gitleaks (previously: silently allowed) |
| `HK=0` / `HK_SKIP_STEPS=gitleaks` | bypass hk only, identity hook still applies |
| `git rebase --root` | succeeds without `HK=0` |

## Known gap

`git commit --author="..."` is invisible to a pre-commit hook, so it is not
covered. The observed failure went through the environment, which is covered.
