### PR TITLE
Use ~ for the author-identity hook command path

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -109,7 +109,7 @@
 # Refuse commits attributed to an identity that is not mine. Config-based hooks
 # are global, so this needs no per-repo install. See the script for the why.
 [hook "author-identity"]
-	command = {{ .chezmoi.homeDir }}/.config/git/hooks/author-identity
+	command = ~/.config/git/hooks/author-identity
 	event = pre-commit
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`hook.author-identity.command` was written as a rendered absolute path. On Windows
that renders `C:\Users\mimikun`, and git's config parser rejects `\U` as a bad
escape sequence:

```
fatal: bad config line 2 in file .gitconfig
```

The failure is not scoped to this key -- the whole file fails to parse, so every
git command on that machine errors out until the line is edited. Nothing is lost,
but the cause is not obvious from the message.

Linux is unaffected, and this machine has not applied on Windows yet, so this is
pre-emptive.

## Solution

Use `~/.config/git/hooks/author-identity`. It matches how the rest of this file
spells home-relative paths (`core.excludesfile`, `init.templatedir`,
`includeIf.path`), contains no backslash on any platform, and is still expanded:
git runs a hook command containing shell metacharacters through the shell.

## Verification

On Linux, after applying:

| Case | Result |
| --- | --- |
| `GIT_AUTHOR_EMAIL=<denied> git commit` | rejected (so `~` resolved -- a missing path would have surfaced as "No such file") |
| `GIT_COMMITTER_EMAIL=<denied> git commit` | rejected |
| normal commit | passes |
| `git config -f <file> --get hook.t.command` on the tilde form | parses cleanly |
