### PR TITLE
docs: record the whitelist trap and the permission-rule behaviour

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# dotfiles（chezmoi source）
+
+`~/.claude` を含む dotfiles の source。**実体を編集して `chezmoi add` すると
+共有の source に書くので、agent は `chezmoi add -S <worktree>` を使う。**
+
+## `~/.claude` は allowlist 方式で管理されている
+
+`.chezmoiignore.tmpl` はまず `.claude/**` を無視し、そのあと `!` 行で個別に戻している。
+
+**つまり `dot_claude/` に新しく置いたファイルは、`!` 行を足すまで黙って管理外になる。**
+意図は「設定だけ管理し、実行時の状態と秘密は無視する」こと。
+
+**忘れたときの症状**: source ツリーに存在するのに
+`chezmoi managed` / `status` / `diff` / `cat` が「管理外」と言う。
+
+**手順**: `dot_claude/` にファイルを足したら `.chezmoiignore.tmpl` に対応する `!` 行を
+足す（例: `!.claude/rules` と `!.claude/rules/**` の2行）。
+`chezmoi apply` の前に `chezmoi status | grep claude` で確認する。
+
+## hook の正規表現を触る前に
+
+**`scripts/test-claude-hooks.sh` を走らせる。113ケースある。**
+
+2026-07-31 に正規表現を3回書き直し、**書き直すたびに前の版の穴が1つ露出した。**
+目視で通ったと判断しないこと。
+
+## 権限と hook の監査
+
+`docs/plan/claude-permission-holes-20260731.md` に記録がある（PR #3556、2026-07-31 マージ）。
+**2026-07-31 時点で全項目クローズ済み。** 再導出せずそちらを読む。
+
+そこに一目では書いていない挙動は `~/.claude/rules/general.md` の 🤖 節にまとめてある。

--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -143,6 +143,14 @@ git push origin HEAD:master
   （`docs/plan/claude-permission-holes-20260731.md` §第5弾 を参照）。
   ファイルルールの中に `:*` を書くのは回避策ではなく明確なバリデーションエラー。
   `:*` の前方一致は `Bash(...)` にしか存在しない。
+  - **先頭の `!` は無視される**（実測）。`Edit(!...)` の除外は一度も効いていなかった。
+    除外したいものは `permissions.ask` に置く。**`ask` は `allow` に勝つ**
+    （`allow` の `Edit(./**)` にも一致するパスで、実際に確認が出た）
+  - **`**` はドット始まりのセグメントに当たらない。** `Edit(./**)` は `.git/` を
+    一度もカバーしていなかった。ルールを試すときは、**他のルールに当たらない
+    ドット無しのパス**（`node_modules/` など）を使う
+  - **権限の挙動を試せるのは `manual mode` だけ**（shift+tab で切替。
+    UI 上の `manual` が内部の `default`）
 - **Plan Mode: `ExitPlanMode` を呼ぶ前に `plan-preview` skill を走らせ、
   計画本文に `Plan preview: <url>` の行を入れる。**
   強制しているのは `reviewable-html-workbench` plugin 同梱の


### PR DESCRIPTION
Both notes lived in `~/.claude/projects/*/memory/` — outside chezmoi, never
backed up, and orphaned the moment the directory name changes.

**New `CLAUDE.md` at the repo root** carries the two things specific to this
repo: `~/.claude` is allowlist-ignored, so a new file under `dot_claude/` stays
silently unmanaged until a `!` line is added; and `scripts/test-claude-hooks.sh`
(113 cases) has to be run before touching a hook regex — the regexes were
rewritten three times on 2026-07-31 and each rewrite exposed a hole the
previous one had.

**`rules/general.md`** gains three measured permission behaviours, placed
next to the ones already there rather than in a second file:

- a leading `!` in a permission rule is ignored, and `ask` outranks `allow`
- `**` does not match dot-leading segments, so `Edit(./**)` never covered `.git/`
- permission probes only mean anything in manual mode