### PR TITLE
docs(rules): note that the ~/.claude source repo is public

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -129,6 +129,9 @@ git push origin HEAD:master
   （`dot_claude/private_settings.json`）。ファイルを直接編集すると drift が発生する。
   編集後に `chezmoi add` を実行するか、`chezmoi edit` を使うこと。
   **git リポジトリかどうかでバックアップの有無を判断しないこと。**
+- **`~/.claude/` のソースリポジトリ `mimikun/dotfiles` は公開。**
+  ここに挙げたファイルを編集すると外から読める。**何を書いてよいかは
+  `CLAUDE.md` の「🧠 memory の置き場所」にある。**
 - `~/ghq/github.com/mimikun/mimikun.claude-code-config/` は放棄済み。読まない、編集しない。
 - **設定キーと環境変数は、勧める前に必ずバイナリに対して検証する:**
   `grep -c '<name>' (readlink -f (which claude))`。settings.json の `env` ブロックは


### PR DESCRIPTION
## 問題

「`mimikun/dotfiles` は公開」という事実が `CLAUDE.md` の「🧠 memory の置き場所」節にしか無い。

`rules/general.md` の「🤖 Claude Code 自身の設定」節は `settings.json` / `hooks/**` の編集手順を書いているのに、**それが外から読めることをどこからも知らせていない。**

## 解決

§🤖 に1行足して、判断基準の本体（`CLAUDE.md` §🧠）へ誘導する。

増えるのは行数ではなく到達経路。判断基準そのものは二重化していない。