### PR TITLE
feat(hooks): inject the measured current time on every prompt

### DIFF
--- a/dot_claude/hooks/executable_inject-current-time.sh
+++ b/dot_claude/hooks/executable_inject-current-time.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # UserPromptSubmit hook: put the real current time into context on every turn.
 #
-# Reason it is not SessionStart: the failure this replaces (M02) is not "the time
-# was never known", it is "a value taken once was extrapolated from". Injecting a
-# single timestamp per session reproduces exactly that, and lends it authority.
-# Turn intervals are unrelated to wall-clock time — the user leaves for hours —
-# so the only safe value is one measured on this turn.
+# Reason it is not SessionStart: the failure this replaces is not "the time was
+# never known", it is "a value taken once was extrapolated from" — readings drifted
+# by 12 to 60 minutes that way, including after a rule said to re-measure.
+# A single timestamp per session reproduces exactly that shape, and lends it the
+# authority of coming from the harness. Turn intervals are unrelated to wall-clock
+# time — hours can pass — so the only safe value is one measured on this turn.
 set -uo pipefail
 
 # Without jq the JSON could not be escaped safely; emitting nothing is correct,
-# since the rule in rules/general.md still says to run `date`.
+# since the "current time" rule in rules/general.md still says to run `date`.
 command -v jq >/dev/null 2>&1 || exit 0
 
 now=$(date '+%Y-%m-%d (%a) %H:%M:%S %Z') || exit 0

--- a/dot_claude/hooks/executable_inject-current-time.sh
+++ b/dot_claude/hooks/executable_inject-current-time.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: put the real current time into context on every turn.
+#
+# Reason it is not SessionStart: the failure this replaces (M02) is not "the time
+# was never known", it is "a value taken once was extrapolated from". Injecting a
+# single timestamp per session reproduces exactly that, and lends it authority.
+# Turn intervals are unrelated to wall-clock time — the user leaves for hours —
+# so the only safe value is one measured on this turn.
+set -uo pipefail
+
+# Without jq the JSON could not be escaped safely; emitting nothing is correct,
+# since the rule in rules/general.md still says to run `date`.
+command -v jq >/dev/null 2>&1 || exit 0
+
+now=$(date '+%Y-%m-%d (%a) %H:%M:%S %Z') || exit 0
+
+read -r -d '' msg <<EOF2 || true
+CURRENT TIME: $now
+
+This was measured when this message was sent, and is the only correct value.
+Do not add elapsed time to it, and do not reuse a timestamp from earlier in the
+conversation — the gap between turns is unrelated to wall-clock time. If a later
+point in this same reply depends on the time, run \`date\` again.
+EOF2
+
+printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":%s}}\n' \
+  "$(jq -Rs . <<<"$msg")"
+exit 0

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -156,6 +156,18 @@
         ],
         "matcher": "*"
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "bash '/home/mimikun/.claude/hooks/inject-current-time.sh'",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
     ]
   },
   "inputNeededNotifEnabled": true,


### PR DESCRIPTION
## 問題

`rules/general.md` の「🕐 現在時刻」は「時刻は推測せず `date` を実行する」というルール文で、**Claude がそれに従うことに依存している。従わなかった。**

セッション中に一度 `date` を実行し、そのあとは**経過時間を頭の中で足して**時刻を書く、という失敗が繰り返し起きた。実測されたずれは 12分 / 29分 / 33分 / 約1時間。

**ルールを追加した後にも同じ形で再発している。** そのときは残り時間を伝える文脈で29分ずれており、**表示の不正確さでは済まない** — 予定までの残り時間として使われる数字だった。

原因は注意力ではなく手順の欠落。**会話のターン間隔は実時間と無関係**で、数時間空くこともある。経過時間の推定は原理的に不可能なので、「だいたい合っているだろう」という前提自体が誤り。

## 解決

`UserPromptSubmit` hook で、**毎ターン実測した時刻を context に注入する。** Claude の意志を経由しないので、従うかどうかが問題にならない。

## なぜ SessionStart ではないか

この失敗は「時刻を知らなかった」ではなく **「一度取った値から経過を足した」**。

セッション開始時に1つだけ注入する形は**その失敗そのものを再現する。** さらに、ハーネスが与えた値なので**正当性まで持ってしまい、かえって悪化する。** 安全なのは、そのターンで測った値だけ。

## 副作用

- 毎ターン約40トークン増える
- `jq` が無い環境では何も出力せずに終了する。ルール文は残るので**退化するだけで壊れない**