### PR TITLE
fix(git): stop paying for hk hooks that have no steps

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -116,21 +116,34 @@
 # git hooks (by hk.jdx.dev)
 # =============================================================================
 
+# hk only defines steps for pre-commit (~/.config/hk/config.pkl), so every hook
+# below starts hk just to have it exit doing nothing. That cost is invisible on a
+# single commit and brutal on a rebase, which fires post-checkout,
+# prepare-commit-msg, post-commit and post-rewrite once per replayed commit:
+# a 20-commit rebase measured 33.6s, and 0.27s with HK=0 (2026-08-13).
+# Re-enable any of these the moment config.pkl grows steps for it.
+# `hk install --global` will drop the `enabled` lines if re-run.
+
 [hook "hk-commit-msg"]
 	command = test \"${HK:-1}\" = \"0\" || hk run commit-msg --from-hook \"$@\"
 	event = commit-msg
+	enabled = false
 [hook "hk-post-checkout"]
 	command = test \"${HK:-1}\" = \"0\" || hk run post-checkout --from-hook \"$@\"
 	event = post-checkout
+	enabled = false
 [hook "hk-post-commit"]
 	command = test \"${HK:-1}\" = \"0\" || hk run post-commit --from-hook \"$@\"
 	event = post-commit
+	enabled = false
 [hook "hk-post-merge"]
 	command = test \"${HK:-1}\" = \"0\" || hk run post-merge --from-hook \"$@\"
 	event = post-merge
+	enabled = false
 [hook "hk-post-rewrite"]
 	command = test \"${HK:-1}\" = \"0\" || hk run post-rewrite --from-hook \"$@\"
 	event = post-rewrite
+	enabled = false
 # No repository here has an hk.pkl, and `--from-hook` makes hk exit 0 silently in
 # that case -- so the steps in ~/.config/hk/config.pkl never ran. Dropping the
 # flag is what makes the global config take effect. `hk install --global` will
@@ -141,6 +154,7 @@
 [hook "hk-pre-push"]
 	command = test \"${HK:-1}\" = \"0\" || hk run pre-push --from-hook \"$@\"
 	event = pre-push
+	enabled = false
 # `git rebase --root` passes no UPSTREAM (and passes `--root` through), but
 # `hk run pre-rebase` requires one, so every rooted rebase is refused. No
 # pre-rebase steps are configured in ~/.config/hk/config.pkl, so this hook can
@@ -152,6 +166,7 @@
 [hook "hk-prepare-commit-msg"]
 	command = test \"${HK:-1}\" = \"0\" || hk run prepare-commit-msg --from-hook \"$@\"
 	event = prepare-commit-msg
+	enabled = false
 
 # =============================================================================
 # git-ai


### PR DESCRIPTION
## Problem

`git rebase` had been slow for a long time. Measured on a scratch repo with 20 commits:

| | 20-commit rebase |
|---|---|
| as-is | **33.6s** |
| `HK=0` | **0.27s** |

CPU sat at 5-6% the whole time, so git was not computing anything -- it was waiting on subprocesses.

`~/.config/hk/config.pkl` defines steps for **`pre-commit` only**, but eleven hooks were registered globally in `~/.gitconfig`. The other ten start `hk` just to have it exit doing nothing, at ~0.38s each.

That cost is invisible on a single commit. A rebase fires `post-checkout`, `prepare-commit-msg`, `post-commit` and `post-rewrite` **once per replayed commit**, so it scales with the size of the rebase.

## Fix

Add `enabled = false` to the seven hk hooks that have no configured steps. `hk-pre-rebase` already had exactly this treatment for the same reason, so this only makes the rest consistent with it.

Disabling rather than deleting: if `config.pkl` ever grows steps for one of these, re-enabling is a one-line deletion.

## Result

| | 20-commit rebase |
|---|---|
| before | 33.6s |
| after | **0.25s** |

`gitleaks` still runs on commit -- verified by making a commit and watching it execute.

## Note

`hk install --global` will drop the `enabled` lines if it is ever re-run. That is written into the file as a comment.