### PR TITLE
chore(claude): sync auto mode settings into chezmoi

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -1,184 +1,8 @@
 {
-  "agentPushNotifEnabled": true,
   "cleanupPeriodDays": 30,
-  "effortLevel": "medium",
-  "enabledPlugins": {
-    "cclens@cclens": true,
-    "i-have-adhd@i-have-adhd": true,
-    "mattpocock-skills@claude-plugins-official": true,
-    "obsidian@obsidian-skills": true,
-    "reviewable-html-workbench@reviewable-html-workbench-local": true,
-    "understand-anything@understand-anything": true
-  },
   "env": {
     "IS_DEMO": "1"
   },
-  "extraKnownMarketplaces": {
-    "cclens": {
-      "source": {
-        "repo": "lambdalisue/cclens",
-        "source": "github"
-      }
-    },
-    "dotnet-agent-skills": {
-      "source": {
-        "repo": "dotnet/skills",
-        "source": "github"
-      }
-    },
-    "i-have-adhd": {
-      "source": {
-        "path": "/home/mimikun/ghq/github.com/ayghri/i-have-adhd",
-        "source": "directory"
-      }
-    },
-    "obsidian-skills": {
-      "source": {
-        "repo": "kepano/obsidian-skills",
-        "source": "github"
-      }
-    },
-    "reviewable-html-workbench-local": {
-      "source": {
-        "repo": "u-ichi/reviewable-html-workbench",
-        "source": "github"
-      }
-    },
-    "understand-anything": {
-      "source": {
-        "repo": "Egonex-AI/Understand-Anything",
-        "source": "github"
-      }
-    }
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      }
-    ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      },
-      {
-        "hooks": [
-          {
-            "command": "rtk hook claude",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/todoist-sync-reminder.sh'",
-            "type": "command"
-          }
-        ],
-        "matcher": "mcp__claude_ai_Todoist__(add|update|delete|complete|uncomplete|reschedule|reorder|manage|project)-"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-push.sh'",
-            "statusMessage": "Checking for destructive push",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/deny-recursive-rm.sh'",
-            "statusMessage": "Checking for recursive rm",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-git.sh'",
-            "statusMessage": "Checking for destructive git",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/deny-interpreter-oneliners.sh'",
-            "statusMessage": "Checking interpreter one-liners",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/check-settings-env.sh'",
-            "timeout": 20,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/herdr-agent-state.sh' session",
-            "timeout": 10,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/check-agent-skills.sh'",
-            "timeout": 15,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "command": "bash '/home/mimikun/.claude/hooks/inject-current-time.sh'",
-            "timeout": 5,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      }
-    ]
-  },
-  "inputNeededNotifEnabled": true,
-  "model": "opus",
   "permissions": {
     "allow": [
       "Bash(npm:*)",
@@ -199,8 +23,6 @@
       "Bash(coverage:*)",
       "Bash(tox:*)",
       "Bash(pyenv:*)",
-      "Bash(python:*)",
-      "Bash(python3:*)",
       "Bash(jupyter:*)",
       "Bash(ipython:*)",
       "Bash(notebook:*)",
@@ -216,14 +38,11 @@
       "Bash(go:*)",
       "Bash(gofmt:*)",
       "Bash(golint:*)",
-      "Bash(node:*)",
-      "Bash(deno:*)",
       "Bash(deno task:*)",
       "Bash(deno test:*)",
       "Bash(deno fmt:*)",
       "Bash(deno lint:*)",
       "Bash(deno compile:*)",
-      "Bash(tsx:*)",
       "Bash(tsc:*)",
       "Bash(ts-node:*)",
       "Bash(eslint:*)",
@@ -298,7 +117,6 @@
       "Bash(touch:*)",
       "Bash(cp:*)",
       "Bash(mv:*)",
-      "Bash(rm:*)",
       "Bash(echo:*)",
       "Bash(which:*)",
       "Bash(pwd)",
@@ -335,15 +153,11 @@
       "Bash(ping:*)",
       "Bash(nslookup:*)",
       "Bash(dig:*)",
-      "Bash(ssh:*)",
       "Bash(scp:*)",
       "Bash(rsync:*)",
-      "Bash(chmod:*)",
-      "Bash(chown:*)",
       "Bash(ln:*)",
       "Bash(date:*)",
       "Bash(whoami)",
-      "Bash(env)",
       "Bash(export:*)",
       "Bash(history)",
       "Bash(alias:*)",
@@ -364,23 +178,8 @@
       "WebFetch(domain:*)",
       "NotebookRead(**)",
       "TodoRead(**)",
-      "TodoWrite(**)",
-      "Task(**)"
+      "TodoWrite(**)"
     ],
-    "ask": [
-      "Edit(**/.git/**)",
-      "Edit(**/node_modules/**)",
-      "Edit(**/vendor/**)",
-      "Edit(**/.venv/**)",
-      "Edit(**/venv/**)",
-      "Edit(**/__pycache__/**)",
-      "Edit(**/target/**)",
-      "Edit(**/dist/**)",
-      "Edit(**/build/**)",
-      "Edit(**/.next/**)",
-      "Edit(**/coverage/**)"
-    ],
-    "defaultMode": "plan",
     "deny": [
       "Bash(rm -rf:*)",
       "Bash(rm -fr:*)",
@@ -418,16 +217,238 @@
       "Edit(/sys/**)",
       "Edit(/dev/**)",
       "Edit(~/.ssh/**)"
-    ]
+    ],
+    "ask": [
+      "Edit(**/.git/**)",
+      "Edit(**/node_modules/**)",
+      "Edit(**/vendor/**)",
+      "Edit(**/.venv/**)",
+      "Edit(**/venv/**)",
+      "Edit(**/__pycache__/**)",
+      "Edit(**/target/**)",
+      "Edit(**/dist/**)",
+      "Edit(**/build/**)",
+      "Edit(**/.next/**)",
+      "Edit(**/coverage/**)"
+    ],
+    "defaultMode": "auto"
   },
+  "model": "opus",
   "skillOverrides": {
     "mattpocock-skills:grilling": "user-invocable-only",
     "officecli": "off"
   },
-  "statusLine": {
-    "command": "bash \"$HOME/.claude/statusline.sh\"",
-    "refreshInterval": 30,
-    "type": "command"
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__claude_ai_Todoist__(add|update|delete|complete|uncomplete|reschedule|reorder|manage|project)-",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/todoist-sync-reminder.sh'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-push.sh'",
+            "statusMessage": "Checking for destructive push"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-recursive-rm.sh'",
+            "statusMessage": "Checking for recursive rm"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-destructive-git.sh'",
+            "statusMessage": "Checking for destructive git"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/deny-interpreter-oneliners.sh'",
+            "statusMessage": "Checking interpreter one-liners"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/check-settings-env.sh'",
+            "timeout": 20
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/check-agent-skills.sh'",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/home/mimikun/.claude/hooks/inject-current-time.sh'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   },
-  "tui": "fullscreen"
+  "statusLine": {
+    "type": "command",
+    "command": "bash \"$HOME/.claude/statusline.sh\"",
+    "refreshInterval": 30
+  },
+  "enabledPlugins": {
+    "cclens@cclens": true,
+    "i-have-adhd@i-have-adhd": true,
+    "mattpocock-skills@claude-plugins-official": true,
+    "obsidian@obsidian-skills": true,
+    "reviewable-html-workbench@reviewable-html-workbench-local": true,
+    "understand-anything@understand-anything": true
+  },
+  "extraKnownMarketplaces": {
+    "cclens": {
+      "source": {
+        "source": "github",
+        "repo": "lambdalisue/cclens"
+      }
+    },
+    "dotnet-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/skills"
+      }
+    },
+    "i-have-adhd": {
+      "source": {
+        "source": "directory",
+        "path": "/home/mimikun/ghq/github.com/ayghri/i-have-adhd"
+      }
+    },
+    "obsidian-skills": {
+      "source": {
+        "source": "github",
+        "repo": "kepano/obsidian-skills"
+      }
+    },
+    "reviewable-html-workbench-local": {
+      "source": {
+        "source": "github",
+        "repo": "u-ichi/reviewable-html-workbench"
+      }
+    },
+    "understand-anything": {
+      "source": {
+        "source": "github",
+        "repo": "Egonex-AI/Understand-Anything"
+      }
+    }
+  },
+  "effortLevel": "medium",
+  "tui": "fullscreen",
+  "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true,
+  "autoMode": {
+    "soft_deny": [
+      "$defaults",
+      "Bash(rm:*) — force-push style irreversible git history rewrite in mimikun/mimikun.agent-system (git push --force / --force-with-lease), matching this repo's own explicit force-push ban"
+    ],
+    "environment": [
+      "### Org-wide",
+      "**Organization**: None configured",
+      "**Cloud provider(s)**: None configured",
+      "**Repository visibility**: private (mimikun/mimikun.agent-system, confirmed via gh)",
+      "**Internal sharing / snippet hosting**: None configured — treat public paste/gist services as outside the trust boundary",
+      "**Secrets management**: None configured",
+      "**Default / protected branches**: master (default); no rulesets or protected-branch rules listed via gh — but this repo's own CLAUDE.md records an explicit owner decision (2026-07-31) permitting direct push to master, and blocks force-push via settings.json + a PreToolUse hook",
+      "**CI/CD deploy targets**: None configured",
+      "**Network posture**: None configured",
+      "**Source control**: The trusted repo (mimikun/mimikun.agent-system) and its origin remote (github.com:mimikun/mimikun.agent-system.git) only — private repo, single author, no additional orgs configured",
+      "**Trusted internal domains**: None configured",
+      "**Trusted cloud buckets**: None configured",
+      "**Key internal services**: None configured",
+      "**Internal package registry**: None configured",
+      "**Sensitive data locations & audiences**: any file or store holding personal data, confidential business data, credentials, regulated data, or similarly sensitive material; preserve exact handles when known and share only with audiences cleared at the [named+specifics] bar. This repo's CLAUDE.md additionally flags health, employment, financial, and personal-situation details as never to be placed in any public repository (the linked dotfiles source repo, mimikun/dotfiles, is public)",
+      "**Data retention / declassification**: None configured",
+      "**Sensitive remote targets**: any namespace, host, or container whose name carries `prod` or `production` as a whole word or name segment",
+      "**Protected deployment namespaces / environments**: None configured — fall back to the Sensitive remote targets heuristic",
+      "**Protected IaC scopes**: IAM, RBAC, networking, quota, and node-pool resources; anything whose name or tag carries `prod` or `production` as a whole word or name segment",
+      "### User-specific",
+      "**Primary use of Claude Code**: software development, personal knowledge/records management (this repo is a personal record-keeping system)",
+      "**Trusted repo**: mimikun/mimikun.agent-system (private, single-author) and its origin remote — direct push to master is explicitly allowed by owner decision recorded in CLAUDE.md; force-push remains blocked",
+      "**Org-specific CLIs**: None configured (non-standard CLIs seen — herdr, chezmoi, neowright, spark, codex, officecli, rumdl, rtk — are personal/hobby tools, not org-specific)",
+      "**routine under mimikun/ prefix**: commits and pushes to master within mimikun/mimikun.agent-system are routine per repo's own documented policy"
+    ]
+  }
 }


### PR DESCRIPTION
## Problem

`/auto-mode-setup` rewrote `~/.claude/settings.json` directly. That file is
chezmoi-managed (`dot_claude/private_settings.json`), so the source was left
out of date — the next `chezmoi apply` would have silently reverted every
change.

## Solution

Re-imported the live file with `chezmoi add`. Verified the source and the live
file are semantically identical (`jq -S` normalized comparison); most of the
line churn is key reordering, not content.

Actual changes carried in:

- `permissions.defaultMode`: `plan` -> `auto`
- new `autoMode` block: environment description + `soft_deny`
- 11 entries dropped from `permissions.allow`, since auto mode would run them
  unattended: `python`, `python3`, `node`, `deno`, `tsx`, `rm`, `ssh`,
  `chmod`, `chown`, `env`, `Task(**)`

The destructive-push `deny` rules and the `ask` rules are untouched.

## Known issue, not fixed here

The single `soft_deny` entry is self-inconsistent: its pattern is `Bash(rm:*)`
but its description talks about irreversible history rewrites. Left as-is to
keep this change to one logical unit. Those rewrites remain blocked by the
`deny` rules and the `PreToolUse` hook regardless.
