### PR TITLE
fix(claude): correct the soft_deny description for rm

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -422,7 +422,7 @@
   "autoMode": {
     "soft_deny": [
       "$defaults",
-      "Bash(rm:*) — force-push style irreversible git history rewrite in mimikun/mimikun.agent-system (git push --force / --force-with-lease), matching this repo's own explicit force-push ban"
+      "Bash(rm:*) — irreversible file deletion. rm is not in permissions.allow, and the prose records under mimikun/mimikun.agent-system are the only copy of content that cannot be regenerated, so deletions must stay confirmed rather than run unattended"
     ],
     "environment": [
       "### Org-wide",


### PR DESCRIPTION
## Problem

Follow-up to #3659, which flagged this but deliberately left it unfixed.

The single `autoMode.soft_deny` entry paired the pattern `Bash(rm:*)` with a
description about irreversible git history rewrites. Those are two unrelated
operations — the pattern never matched what the description claimed to guard.

## Solution

Keep the pattern, rewrite the description to say what `Bash(rm:*)` actually
matches: irreversible file deletion, on a machine where the prose records are
the only copy of content that cannot be regenerated.

History rewrites lose no protection from this — they stay blocked by the
`permissions.deny` rules and the `PreToolUse` hook, independently of
`soft_deny`.

One line changed; the live `~/.claude/settings.json` and this source file were
verified identical after the edit.
