### PR TITLE
chore(claude): record where the agmsg skill comes from

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
@@ -59,6 +59,21 @@ elif command -v officecli >/dev/null 2>&1; then
     officecli skills install claude
 fi
 
+# --- skills with their own installer ----------------------------------------
+# agmsg (https://github.com/fujibee/agmsg, MIT) ships its own bootstrapper, so
+# it joins neither the `npx skills` loop above nor a CLI subcommand. `npx agmsg`
+# is the tagged-release path; the git clone and setup.sh paths track main and
+# would report a version like v1.1.13-6-g1a2b3c4 instead.
+#
+# It also drops ~/.claude/commands/agmsg.md and a hook, which is why neither is
+# tracked in this repository: reinstalling the skill restores them.
+if [[ -d "$skills_dir/agmsg" ]]; then
+    echo "skill 'agmsg' is already installed."
+else
+    echo "Installing skill 'agmsg' from fujibee/agmsg"
+    npx -y agmsg
+fi
+
 # --- CLIs the skills drive --------------------------------------------------
 # A skill whose CLI is missing looks installed but fails on its first command,
 # so report the gap rather than leaving it silent.
@@ -72,6 +87,9 @@ check_cli herdr       herdr       "https://github.com/ogulcancelik/herdr"
 check_cli neowright   neowright   "https://github.com/isak102/neowright"
 check_cli officecli   officecli   "https://github.com/iOfficeAI/OfficeCLI"
 check_cli spark       use-spark   "ships with Spark Desktop, which must be running"
+# agmsg calls its own scripts rather than a binary on PATH, but every one of
+# them reads a SQLite file, so sqlite3 is the dependency worth reporting.
+check_cli sqlite3     agmsg       "https://github.com/fujibee/agmsg"
 
 # gh-stack drives a gh extension, not a binary on PATH, so check_cli cannot see
 # it. Nothing in this repo reinstalls gh extensions, so a fresh machine gets the


### PR DESCRIPTION
## Problem

`agmsg` was the one skill under `~/.agents/skills/` this script did not cover,
so a fresh machine came up without it and nothing recorded where it came from.
`.skill-lock.json` does not help — it lists only `gh-stack`.

The origin was not written down anywhere obvious: `SKILL.md` carries no upstream
link. It turned up in `scripts/delivery.sh` and `scripts/release/update-cask.sh`,
which point at https://github.com/fujibee/agmsg (MIT).

## Solution

Add agmsg to the script. It ships its own bootstrapper, so it fits neither the
`npx skills` loop nor the CLI-subcommand block and gets a section of its own.

`npx agmsg` is the right install path rather than the git clone or `setup.sh`
one-liner: the installed `VERSION` reads `v1.1.13`, a clean tag, while the two
paths that track `main` report something like `v1.1.13-6-g1a2b3c4`. The Claude
Code plugin path is ruled out too — no agmsg marketplace is registered.

Also adds a `check_cli` line for `sqlite3`. agmsg calls its own scripts rather
than a binary on `PATH`, so the existing checks cannot see it, but every script
reads a SQLite file and the skill fails on first use without it.

## Why `~/.claude/commands/agmsg.md` stays untracked

The installer places that file and a hook alongside the skill, so reinstalling
restores them. Committing a copy would fork a fragment of someone else's package
away from its source.

Checked with `bash -n` after stripping the template lines.
