### PR TITLE
feat(claude): add last30days plugin and its marketplace

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -37,6 +37,7 @@
   "enabledPlugins": {
     "cclens@cclens": true,
     "i-have-adhd@i-have-adhd": true,
+    "last30days@last30days-skill": true,
     "mattpocock-skills@claude-plugins-official": true,
     "obsidian@obsidian-skills": true,
     "reviewable-html-workbench@reviewable-html-workbench-local": true,
@@ -62,6 +63,12 @@
       "source": {
         "path": "/home/mimikun/ghq/github.com/ayghri/i-have-adhd",
         "source": "directory"
+      }
+    },
+    "last30days-skill": {
+      "source": {
+        "repo": "mvanhorn/last30days-skill",
+        "source": "github"
       }
     },
     "obsidian-skills": {


### PR DESCRIPTION
## Problem

`/plugin marketplace add mvanhorn/last30days-skill` と `/plugin install last30days@last30days-skill` を実行したが、その結果は `~/.claude/settings.json` にしか書かれておらず、chezmoi source 側は古いまま。別マシンで復元すると last30days が消える。

## Solution

`dot_claude/private_settings.json` に2箇所追加。

- `enabledPlugins` に `last30days@last30days-skill`
- `extraKnownMarketplaces` に `last30days-skill` (github: mvanhorn/last30days-skill)

実ファイルとの差分は sorted JSON で突き合わせ済みで、他に drift は無いことを確認した。既存の整形（キーソート・2スペース）を保っている。