### PR TITLE
Comment out the aqua entries that home-manager now provides

### DIFF
--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -1,64 +1,75 @@
 ---
+# Tools that home-manager (nixpkgs) now provides are commented out below
+# rather than deleted. The declarations live in mimikun/mimikun.home-manager
+# under packages/cli.nix and packages/dev-tools.nix.
+#
+# Keeping the lines documents what moved, and makes a rollback a one-character
+# edit if a nixpkgs version turns out to be unusable.
+#
+# Still owned by aqua: tools nixpkgs does not package, xcbeautify (macOS only),
+# the Go toolchain (mise owns language runtimes), PowerShell (two versions plus
+# an alias -- undecided), and three name collisions where the nixpkgs attribute
+# ships unrelated software: qq, gama, pingu.
 packages:
-  - name: ahmetb/kubectx@v0.11.0
+  #- name: ahmetb/kubectx@v0.11.0
   - name: aquaproj/registry-tool@v0.5.7
-  - name: aquasecurity/trivy@v0.74.0
-  - name: aristocratos/btop@v1.4.7
-  - name: astral-sh/ruff@0.16.3
-  - name: astral-sh/uv@0.12.5
-  - name: babarot/gomi@v1.6.4
-  - name: bcicen/ctop@v0.7.7
-  - name: bitwarden/clients@cli-v2026.7.0
-  - name: charmbracelet/mods@v1.8.1
-  - name: cli/cli@v2.97.0
+  #- name: aquasecurity/trivy@v0.74.0
+  #- name: aristocratos/btop@v1.4.7
+  #- name: astral-sh/ruff@0.16.3
+  #- name: astral-sh/uv@0.12.5
+  #- name: babarot/gomi@v1.6.4
+  #- name: bcicen/ctop@v0.7.7
+  #- name: bitwarden/clients@cli-v2026.7.0
+  #- name: charmbracelet/mods@v1.8.1
+  #- name: cli/cli@v2.97.0
   - name: cpisciotta/xcbeautify@3.2.1
   - name: CyberAgent/reminder-lint@0.2.1
   - name: dagu-org/dagu@v2.14.0
-  - name: danvergara/dblab@v0.48.0
-  - name: derailed/k9s@v0.51.0
-  - name: direnv/direnv@v2.37.1
-  - name: dlvhdr/diffnav@v0.12.0
-  - name: dominikh/go-tools/staticcheck@2026.1
-  - name: dotenvx/dotenvx@v2.21.0
-  - name: dundee/gdu@v5.36.1
-  - name: fastfetch-cli/fastfetch@2.67.1
-  - name: git-bug/git-bug@v0.10.1
-  - name: gitleaks/gitleaks@v8.30.1
-  - name: gleam-lang/gleam@v1.18.1
+  #- name: danvergara/dblab@v0.48.0
+  #- name: derailed/k9s@v0.51.0
+  #- name: direnv/direnv@v2.37.1
+  #- name: dlvhdr/diffnav@v0.12.0
+  #- name: dominikh/go-tools/staticcheck@2026.1
+  #- name: dotenvx/dotenvx@v2.21.0
+  #- name: dundee/gdu@v5.36.1
+  #- name: fastfetch-cli/fastfetch@2.67.1
+  #- name: git-bug/git-bug@v0.10.1
+  #- name: gitleaks/gitleaks@v8.30.1
+  #- name: gleam-lang/gleam@v1.18.1
   - name: golang/go@go1.26.6
-  - name: golang/tools/gorename@v0.25.0
-  - name: grafana/k6@v2.2.0
-  - name: guumaster/hostctl@v1.1.4
-  - name: hadolint/hadolint@v2.15.1
-  - name: idursun/jjui@v0.10.9
-  - name: jesseduffield/horcrux@v0.2
+  #- name: golang/tools/gorename@v0.25.0
+  #- name: grafana/k6@v2.2.0
+  #- name: guumaster/hostctl@v1.1.4
+  #- name: hadolint/hadolint@v2.15.1
+  #- name: idursun/jjui@v0.10.9
+  #- name: jesseduffield/horcrux@v0.2
   - name: JFryy/qq@v0.3.4
-  - name: jqlang/jq@jq-1.8.2
-  - name: junegunn/fzf@v0.74.2
-  - name: kdabir/has@v1.5.2
-  - name: koalaman/shellcheck@v0.11.0
-  - name: kubescape/kubescape@v4.0.12
-  - name: loeffel-io/ls-lint@v2.3.1
+  #- name: jqlang/jq@jq-1.8.2
+  #- name: junegunn/fzf@v0.74.2
+  #- name: kdabir/has@v1.5.2
+  #- name: koalaman/shellcheck@v0.11.0
+  #- name: kubescape/kubescape@v4.0.12
+  #- name: loeffel-io/ls-lint@v2.3.1
   - name: Macmod/godap@v2.12.0
-  - name: mr-karan/doggo@v1.3.0
-  - name: mrtazz/checkmake@v0.3.2
-  - name: muesli/duf@v0.9.1
-  - name: naggie/dstask@v1.0.1
-  - name: natecraddock/zf@0.10.2
-  - name: pamburus/hl@v0.36.3
+  #- name: mr-karan/doggo@v1.3.0
+  #- name: mrtazz/checkmake@v0.3.2
+  #- name: muesli/duf@v0.9.1
+  #- name: naggie/dstask@v1.0.1
+  #- name: natecraddock/zf@0.10.2
+  #- name: pamburus/hl@v0.36.3
   - name: pkgxdev/pkgx@v2.11.0
-  - name: project-copacetic/copacetic@v0.14.2
-  - name: pvolok/mprocs@v0.9.6
-  - name: sclevine/yj@v5.1.0
+  #- name: project-copacetic/copacetic@v0.14.2
+  #- name: pvolok/mprocs@v0.9.6
+  #- name: sclevine/yj@v5.1.0
   - name: sheepla/pingu@v0.0.5
-  - name: sqshq/sampler@v1.1.0
+  #- name: sqshq/sampler@v1.1.0
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: termkit/gama@v1.2.1
-  - name: tsenart/vegeta@v12.13.0
-  - name: tsl0922/ttyd@1.7.7
-  - name: tstack/lnav@v0.14.0
-  - name: twitchdev/twitch-cli@v1.1.24
-  - name: twpayne/chezmoi@v2.72.0
+  #- name: tsenart/vegeta@v12.13.0
+  #- name: tsl0922/ttyd@1.7.7
+  #- name: tstack/lnav@v0.14.0
+  #- name: twitchdev/twitch-cli@v1.1.24
+  #- name: twpayne/chezmoi@v2.72.0
   - name: wtetsu/gaze@v1.2.1
-  - name: yassinebenaid/bunster@v0.14.0
-  - name: yorukot/superfile@v1.6.0
+  #- name: yassinebenaid/bunster@v0.14.0
+  #- name: yorukot/superfile@v1.6.0

--- a/dot_config/aqua/aqua/custom.yaml
+++ b/dot_config/aqua/aqua/custom.yaml
@@ -1,10 +1,13 @@
 ---
+# github.com/kisielk/errcheck is commented out because home-manager (nixpkgs)
+# now provides it as the errcheck package. See mimikun/mimikun.home-manager,
+# packages/dev-tools.nix. The remaining entries have no nixpkgs equivalent.
 packages:
   # Use custom registry
   - name: mikuta0407/misskey-cli@v0.4.0
     registry: github-release
   - name: Mayowa-Ojo/chmod-cli@v0.2.0
     registry: github-release
-  - name: github.com/kisielk/errcheck
-    registry: go-install
-    version: 'v1.6.3'
+  #- name: github.com/kisielk/errcheck
+  #  registry: go-install
+  #  version: 'v1.6.3'

--- a/dot_config/aqua/aqua/other.yaml
+++ b/dot_config/aqua/aqua/other.yaml
@@ -1,4 +1,9 @@
 ---
+# ncdu is commented out because home-manager (nixpkgs) now provides it. See
+# mimikun/mimikun.home-manager, packages/cli.nix.
+#
+# PowerShell stays here for now: aqua declares two versions with a pwsh-unstable
+# alias, and a single home.packages entry cannot express that. Undecided.
 packages:
   # Multi version
   - name: PowerShell/PowerShell@v7.6.5
@@ -8,5 +13,5 @@ packages:
       - command: pwsh
         alias: pwsh-unstable
   # Not GitHub hosted
-  - name: dev.yorhel.nl/ncdu
-    version: '2.4'
+  #- name: dev.yorhel.nl/ncdu
+  #  version: '2.4'


### PR DESCRIPTION
## Problem

52 tools were declared in both aqua and home-manager once the nixpkgs
migration landed. Two package managers installing the same binary means the
PATH order silently decides which one runs, and both keep downloading updates.

## Solution

Comment the duplicated entries out of the aqua config instead of deleting
them:

| file | commented out | left declared |
|---|---|---|
| `aqua/aqua.yaml` | 50 | 12 |
| `aqua/custom.yaml` | 1 (`errcheck`) | 2 |
| `aqua/other.yaml` | 1 (`ncdu`) | 2 (PowerShell) |

Commenting rather than deleting keeps a record of what moved and makes a
rollback a one-character edit if a nixpkgs version turns out to be unusable.
Each file gained a header explaining where the declarations went.

## What deliberately stays with aqua

- **Not packaged in nixpkgs:** `aquaproj/registry-tool`,
  `CyberAgent/reminder-lint`, `dagu-org/dagu`, `Macmod/godap`, `pkgxdev/pkgx`,
  `suzuki-shunsuke/cmdx`, `wtetsu/gaze`, `mikuta0407/misskey-cli`,
  `Mayowa-Ojo/chmod-cli`
- **macOS only:** `cpisciotta/xcbeautify` refuses to evaluate on
  `x86_64-linux`
- **`golang/go`:** mise owns language runtimes
- **PowerShell:** two versions plus a `pwsh-unstable` alias, which a single
  `home.packages` entry cannot express — still undecided
- **Name collisions:** the nixpkgs attributes `qq`, `gama` and `pingu` ship
  unrelated software (Tencent QQ, GNU Gama, and a different pingu), so those
  three stay with aqua

## Verification

Each of the 52 commented entries was checked against the home-manager branch:
every one has a matching declaration in `packages/cli.nix` or
`packages/dev-tools.nix`. All three YAML files still parse, and the remaining
package counts are 12 / 2 / 2.

## Ordering note

This change is inert until `aqua i` runs. Apply it only after the
home-manager side is activated, otherwise a prune would remove tools that
nixpkgs has not installed yet.
