### PR TITLE
Keep gorename with aqua

### DIFF
--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -10,6 +10,12 @@
 # the Go toolchain (mise owns language runtimes), PowerShell (two versions plus
 # an alias -- undecided), and three name collisions where the nixpkgs attribute
 # ships unrelated software: qq, gama, pingu.
+#
+# Two commands change name under nixpkgs: ls-lint becomes ls_lint, and
+# superfile installs as superfile rather than spf.
+#
+# gorename stays with aqua: it is not part of the nixpkgs gotools package,
+# because upstream removed it from x/tools.
 packages:
   #- name: ahmetb/kubectx@v0.11.0
   - name: aquaproj/registry-tool@v0.5.7
@@ -37,7 +43,7 @@ packages:
   #- name: gitleaks/gitleaks@v8.30.1
   #- name: gleam-lang/gleam@v1.18.1
   - name: golang/go@go1.26.6
-  #- name: golang/tools/gorename@v0.25.0
+  - name: golang/tools/gorename@v0.25.0
   #- name: grafana/k6@v2.2.0
   #- name: guumaster/hostctl@v1.1.4
   #- name: hadolint/hadolint@v2.15.1


### PR DESCRIPTION
## Problem

PR #3670 commented out `golang/tools/gorename` on the assumption that the
nixpkgs `gotools` package provides it. It does not - upstream removed
`gorename` from x/tools - so applying #3670 as merged would drop the tool with
nothing to replace it.

## Solution

Restore the `gorename` declaration in `aqua/aqua.yaml`, and record two more
facts in the file header:

- `ls-lint` installs as `ls_lint` under nixpkgs
- `superfile` installs as `superfile`, not `spf`

`gotools` has been removed from the home-manager side in
mimikun.home-manager#4, since covering `gorename` was its only reason to be
there.

## Verification

`gorename` is absent from the activated profile, while the other 49 commented
entries all resolve: every aqua command that was commented out has a
counterpart in `~/.nix-profile/bin`, except the three noted here.