### PR TITLE
Hand PowerShell over to home-manager

### DIFF
--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -7,9 +7,11 @@
 # edit if a nixpkgs version turns out to be unusable.
 #
 # Still owned by aqua: tools nixpkgs does not package, xcbeautify (macOS only),
-# the Go toolchain (mise owns language runtimes), PowerShell (two versions plus
-# an alias -- undecided), and three name collisions where the nixpkgs attribute
-# ships unrelated software: qq, gama, pingu.
+# the Go toolchain (mise owns language runtimes), and three name collisions
+# where the nixpkgs attribute ships unrelated software: qq, gama, pingu.
+#
+# PowerShell moved to home-manager; see the header of other.yaml for why the
+# preview version was dropped instead of reproduced.
 #
 # Two commands change name under nixpkgs: ls-lint becomes ls_lint, and
 # superfile installs as superfile rather than spf.

--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -10,8 +10,8 @@
 # the Go toolchain (mise owns language runtimes), and three name collisions
 # where the nixpkgs attribute ships unrelated software: qq, gama, pingu.
 #
-# PowerShell moved to home-manager; see the header of other.yaml for why the
-# preview version was dropped instead of reproduced.
+# PowerShell moved to home-manager, preview included; see the header of
+# other.yaml for how the two versions are kept apart there.
 #
 # Two commands change name under nixpkgs: ls-lint becomes ls_lint, and
 # superfile installs as superfile rather than spf.

--- a/dot_config/aqua/aqua/other.yaml
+++ b/dot_config/aqua/aqua/other.yaml
@@ -4,15 +4,17 @@
 # ncdu moved to home-manager (nixpkgs). See mimikun/mimikun.home-manager,
 # packages/cli.nix.
 #
-# PowerShell also moved. aqua declared two versions here: stable 7.6.5, and
-# 7.7.0-preview.3 exposed as pwsh-unstable. The preview is unused and was
-# dropped rather than reproduced -- nixpkgs has no preview attribute, and
-# home.packages has no equivalent of command_aliases, so keeping it would have
-# meant carrying a second source of PowerShell for a command nobody runs.
+# PowerShell also moved, both versions of it. nixpkgs has one PowerShell
+# attribute, pinned to the stable line at 7.6.4, and no preview, so
+# overlays/powershell.nix on the home-manager side supplies all three pieces:
 #
-# nixpkgs ships 7.6.4, one patch behind what aqua installed, so the stable
-# version is pinned to 7.6.5 by overlays/powershell.nix on the home-manager
-# side. The version does not regress.
+#   powershell     stable, pinned forward to 7.6.5 so it does not regress
+#   pwsh-unstable  the 7.7.0-preview.3 build, under the same command name
+#                  aqua exposed it as
+#
+# The preview needed the extra hop because both derivations install bin/pwsh
+# and a share/powershell tree; putting both in the profile fails to build on
+# the collision. Only a one-binary wrapper around the preview goes in.
 packages:
   # Multi version
   #- name: PowerShell/PowerShell@v7.6.5

--- a/dot_config/aqua/aqua/other.yaml
+++ b/dot_config/aqua/aqua/other.yaml
@@ -1,17 +1,26 @@
 ---
-# ncdu is commented out because home-manager (nixpkgs) now provides it. See
-# mimikun/mimikun.home-manager, packages/cli.nix.
+# Everything in this file is handled elsewhere now; nothing is left for aqua.
 #
-# PowerShell stays here for now: aqua declares two versions with a pwsh-unstable
-# alias, and a single home.packages entry cannot express that. Undecided.
+# ncdu moved to home-manager (nixpkgs). See mimikun/mimikun.home-manager,
+# packages/cli.nix.
+#
+# PowerShell also moved. aqua declared two versions here: stable 7.6.5, and
+# 7.7.0-preview.3 exposed as pwsh-unstable. The preview is unused and was
+# dropped rather than reproduced -- nixpkgs has no preview attribute, and
+# home.packages has no equivalent of command_aliases, so keeping it would have
+# meant carrying a second source of PowerShell for a command nobody runs.
+#
+# nixpkgs ships 7.6.4, one patch behind what aqua installed, so the stable
+# version is pinned to 7.6.5 by overlays/powershell.nix on the home-manager
+# side. The version does not regress.
 packages:
   # Multi version
-  - name: PowerShell/PowerShell@v7.6.5
-  - name: PowerShell/PowerShell
-    version: v7.7.0-preview.3
-    command_aliases:
-      - command: pwsh
-        alias: pwsh-unstable
+  #- name: PowerShell/PowerShell@v7.6.5
+  #- name: PowerShell/PowerShell
+  #  version: v7.7.0-preview.3
+  #  command_aliases:
+  #    - command: pwsh
+  #      alias: pwsh-unstable
   # Not GitHub hosted
   #- name: dev.yorhel.nl/ncdu
   #  version: '2.4'


### PR DESCRIPTION
## Problem

PowerShell was the last tool still declared in aqua that home-manager could
take over. It was left behind in #3670 because aqua declares two versions:
stable 7.6.5, and 7.7.0-preview.3 exposed as **pwsh-unstable** through
**command_aliases**. nixpkgs has one PowerShell attribute, pinned to the
stable line at 7.6.4, and no preview at all.

## Solution

Comment out both entries. Both versions survive the move — the home-manager
side reproduces the whole arrangement with an overlay
(mimikun.home-manager#5):

| command | before, from aqua | after, from nixpkgs |
|---|---|---|
| `pwsh` | 7.6.5 | 7.6.5, pinned forward past the 7.6.4 nixpkgs ships |
| `pwsh-unstable` | 7.7.0-preview.3 | 7.7.0-preview.3 |

Nothing regresses and nothing is dropped.

The preview needed an extra hop on that side: both PowerShell derivations
install `bin/pwsh` and a `share/powershell` tree, so putting both in the
profile fails to build on the collision. Only a one-binary wrapper around the
preview enters the profile. The reasoning is recorded in the `other.yaml`
header, which now declares nothing at all.

## Verification

    AQUA_CONFIG=<this branch> aqua list --installed

resolves the remaining 15 declarations (13 in `aqua.yaml`, 2 in
`custom.yaml`), reports no PowerShell, and raises no parse error on the
now-empty `other.yaml`.

On the home-manager side the profile was built for real, and both commands
run: `pwsh` reports 7.6.5, `pwsh-unstable` reports 7.7.0-preview.3.

## Ordering

Merge and activate the home-manager side first. Running `chezmoi apply`
before `home-manager switch` would leave PowerShell uninstalled in between.
