### PR TITLE
Empty aqua out: move go to mise, drop xcbeautify and gorename

### DIFF
--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -6,13 +6,16 @@
 # Keeping the lines documents what moved, and makes a rollback a one-character
 # edit if a nixpkgs version turns out to be unusable.
 #
-# Three declarations are left, and each has a reason that is not "nobody got
-# to it yet":
+# Two declarations are left, and neither is in use:
 #
 #   cpisciotta/xcbeautify   macOS only; refuses to evaluate on x86_64-linux
 #   golang/go               mise owns language runtimes
-#   golang/tools/gorename   deleted upstream at x/tools v0.26.0, so it is not
-#                           in the nixpkgs gotools package either
+#
+# gorename is retired rather than migrated. Upstream deleted it at x/tools
+# v0.26.0 (golang/go#69360) because gopls covers renaming, gopls is installed
+# and wired into the editor as an LSP, and gorename appears zero times in
+# 71920 lines of shell history -- against gopls appearing in the same file, so
+# the count means "never run", not "no history".
 #
 # Everything else, including the tools nixpkgs does not package and the three
 # whose nixpkgs attribute name belongs to unrelated software (qq, gama,
@@ -50,7 +53,7 @@ packages:
   #- name: gitleaks/gitleaks@v8.30.1
   #- name: gleam-lang/gleam@v1.18.1
   - name: golang/go@go1.26.6
-  - name: golang/tools/gorename@v0.25.0
+  #- name: golang/tools/gorename@v0.25.0
   #- name: grafana/k6@v2.2.0
   #- name: guumaster/hostctl@v1.1.4
   #- name: hadolint/hadolint@v2.15.1

--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -6,16 +6,19 @@
 # Keeping the lines documents what moved, and makes a rollback a one-character
 # edit if a nixpkgs version turns out to be unusable.
 #
-# Two declarations are left, and neither is in use:
+# Nothing is declared here any more. Where each thing went:
 #
-#   cpisciotta/xcbeautify   macOS only; refuses to evaluate on x86_64-linux
-#   golang/go               mise owns language runtimes
-#
-# gorename is retired rather than migrated. Upstream deleted it at x/tools
-# v0.26.0 (golang/go#69360) because gopls covers renaming, gopls is installed
-# and wired into the editor as an LSP, and gorename appears zero times in
-# 71920 lines of shell history -- against gopls appearing in the same file, so
-# the count means "never run", not "no history".
+#   most tools              nixpkgs, via home-manager
+#   the ones nixpkgs lacks  overlays/prebuilt-github-tools.nix, which installs
+#                           the same upstream release binaries aqua fetched
+#   golang/go               mise, next to the other language runtimes
+#   cpisciotta/xcbeautify   dropped; macOS only, it never ran on this machine
+#   golang/tools/gorename   dropped; deleted upstream at x/tools v0.26.0
+#                           (golang/go#69360) because gopls covers renaming.
+#                           gopls is installed and wired in as an LSP, and
+#                           gorename appears zero times in 71920 lines of shell
+#                           history -- against gopls appearing in the same file,
+#                           so the count means "never run", not "no history"
 #
 # Everything else, including the tools nixpkgs does not package and the three
 # whose nixpkgs attribute name belongs to unrelated software (qq, gama,
@@ -38,7 +41,7 @@ packages:
   #- name: bitwarden/clients@cli-v2026.7.0
   #- name: charmbracelet/mods@v1.8.1
   #- name: cli/cli@v2.97.0
-  - name: cpisciotta/xcbeautify@3.2.1
+  #- name: cpisciotta/xcbeautify@3.2.1
   #- name: CyberAgent/reminder-lint@0.2.1
   #- name: dagu-org/dagu@v2.14.0
   #- name: danvergara/dblab@v0.48.0
@@ -52,7 +55,7 @@ packages:
   #- name: git-bug/git-bug@v0.10.1
   #- name: gitleaks/gitleaks@v8.30.1
   #- name: gleam-lang/gleam@v1.18.1
-  - name: golang/go@go1.26.6
+  #- name: golang/go@go1.26.6
   #- name: golang/tools/gorename@v0.25.0
   #- name: grafana/k6@v2.2.0
   #- name: guumaster/hostctl@v1.1.4

--- a/dot_config/aqua/aqua/aqua.yaml
+++ b/dot_config/aqua/aqua/aqua.yaml
@@ -6,21 +6,26 @@
 # Keeping the lines documents what moved, and makes a rollback a one-character
 # edit if a nixpkgs version turns out to be unusable.
 #
-# Still owned by aqua: tools nixpkgs does not package, xcbeautify (macOS only),
-# the Go toolchain (mise owns language runtimes), and three name collisions
-# where the nixpkgs attribute ships unrelated software: qq, gama, pingu.
+# Three declarations are left, and each has a reason that is not "nobody got
+# to it yet":
 #
-# PowerShell moved to home-manager, preview included; see the header of
-# other.yaml for how the two versions are kept apart there.
+#   cpisciotta/xcbeautify   macOS only; refuses to evaluate on x86_64-linux
+#   golang/go               mise owns language runtimes
+#   golang/tools/gorename   deleted upstream at x/tools v0.26.0, so it is not
+#                           in the nixpkgs gotools package either
+#
+# Everything else, including the tools nixpkgs does not package and the three
+# whose nixpkgs attribute name belongs to unrelated software (qq, gama,
+# pingu), now comes from overlays in mimikun/mimikun.home-manager.
+#
+# PowerShell moved too, preview included; see the header of other.yaml for how
+# the two versions are kept apart there.
 #
 # Two commands change name under nixpkgs: ls-lint becomes ls_lint, and
 # superfile installs as superfile rather than spf.
-#
-# gorename stays with aqua: it is not part of the nixpkgs gotools package,
-# because upstream removed it from x/tools.
 packages:
   #- name: ahmetb/kubectx@v0.11.0
-  - name: aquaproj/registry-tool@v0.5.7
+  #- name: aquaproj/registry-tool@v0.5.7
   #- name: aquasecurity/trivy@v0.74.0
   #- name: aristocratos/btop@v1.4.7
   #- name: astral-sh/ruff@0.16.3
@@ -31,8 +36,8 @@ packages:
   #- name: charmbracelet/mods@v1.8.1
   #- name: cli/cli@v2.97.0
   - name: cpisciotta/xcbeautify@3.2.1
-  - name: CyberAgent/reminder-lint@0.2.1
-  - name: dagu-org/dagu@v2.14.0
+  #- name: CyberAgent/reminder-lint@0.2.1
+  #- name: dagu-org/dagu@v2.14.0
   #- name: danvergara/dblab@v0.48.0
   #- name: derailed/k9s@v0.51.0
   #- name: direnv/direnv@v2.37.1
@@ -51,33 +56,33 @@ packages:
   #- name: hadolint/hadolint@v2.15.1
   #- name: idursun/jjui@v0.10.9
   #- name: jesseduffield/horcrux@v0.2
-  - name: JFryy/qq@v0.3.4
+  #- name: JFryy/qq@v0.3.4
   #- name: jqlang/jq@jq-1.8.2
   #- name: junegunn/fzf@v0.74.3
   #- name: kdabir/has@v1.5.2
   #- name: koalaman/shellcheck@v0.11.0
   #- name: kubescape/kubescape@v4.0.12
   #- name: loeffel-io/ls-lint@v2.3.1
-  - name: Macmod/godap@v2.12.0
+  #- name: Macmod/godap@v2.12.0
   #- name: mr-karan/doggo@v1.3.0
   #- name: mrtazz/checkmake@v0.3.2
   #- name: muesli/duf@v0.9.1
   #- name: naggie/dstask@v1.0.1
   #- name: natecraddock/zf@0.10.2
   #- name: pamburus/hl@v0.36.3
-  - name: pkgxdev/pkgx@v2.11.0
+  #- name: pkgxdev/pkgx@v2.11.0
   #- name: project-copacetic/copacetic@v0.14.2
   #- name: pvolok/mprocs@v0.9.6
   #- name: sclevine/yj@v5.1.0
-  - name: sheepla/pingu@v0.0.5
+  #- name: sheepla/pingu@v0.0.5
   #- name: sqshq/sampler@v1.1.0
-  - name: suzuki-shunsuke/cmdx@v2.0.2
-  - name: termkit/gama@v1.2.1
+  #- name: suzuki-shunsuke/cmdx@v2.0.2
+  #- name: termkit/gama@v1.2.1
   #- name: tsenart/vegeta@v12.13.0
   #- name: tsl0922/ttyd@1.7.7
   #- name: tstack/lnav@v0.14.0
   #- name: twitchdev/twitch-cli@v1.1.24
   #- name: twpayne/chezmoi@v2.72.0
-  - name: wtetsu/gaze@v1.2.1
+  #- name: wtetsu/gaze@v1.2.1
   #- name: yassinebenaid/bunster@v0.14.0
   #- name: yorukot/superfile@v1.6.0

--- a/dot_config/aqua/aqua/custom.yaml
+++ b/dot_config/aqua/aqua/custom.yaml
@@ -1,13 +1,18 @@
 ---
-# github.com/kisielk/errcheck is commented out because home-manager (nixpkgs)
-# now provides it as the errcheck package. See mimikun/mimikun.home-manager,
-# packages/dev-tools.nix. The remaining entries have no nixpkgs equivalent.
+# This file declares nothing now; all three entries moved to home-manager.
+#
+# errcheck is packaged in nixpkgs directly. misskey-cli and chmod-cli are not,
+# so they come from overlays/prebuilt-github-tools.nix, which installs the same
+# upstream release binaries this file used to fetch.
+#
+# The two local registries under ../registries/ are still referenced by
+# ../aqua.yaml and are left alone; nothing uses them at the moment.
 packages:
   # Use custom registry
-  - name: mikuta0407/misskey-cli@v0.4.0
-    registry: github-release
-  - name: Mayowa-Ojo/chmod-cli@v0.2.0
-    registry: github-release
+  #- name: mikuta0407/misskey-cli@v0.4.0
+  #  registry: github-release
+  #- name: Mayowa-Ojo/chmod-cli@v0.2.0
+  #  registry: github-release
   #- name: github.com/kisielk/errcheck
   #  registry: go-install
   #  version: 'v1.6.3'

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -2,6 +2,10 @@
 # single
 dotnet-core = "latest"
 erlang = "latest"
+# Moved off aqua. A language runtime belongs with the other runtimes, and
+# idiomatic_version_file_enable_tools below already listed go, so the setting
+# was in place before the tool was declared.
+go = "latest"
 lua = "5.1"
 pkl = "latest"
 ruby = "latest"


### PR DESCRIPTION
## What

**aqua ends up declaring nothing.** This is the last step of the migration:
home-manager packages everything that was worth moving
(mimikun.home-manager#6), `go` goes to mise, and two tools are retired rather
than migrated.

| file | commented out | still declared |
|---|---|---|
| `aqua/aqua.yaml` | 13 | **0** |
| `aqua/custom.yaml` | 2 | **0** |
| `aqua/other.yaml` | 2 | **0** |

## Where each thing went

| | destination |
|---|---|
| most tools | nixpkgs, via home-manager |
| the ones nixpkgs lacks | `overlays/prebuilt-github-tools.nix`, installing the same upstream release binaries aqua fetched |
| PowerShell, both versions | `overlays/powershell.nix`, stable pinned to 7.6.5 and the preview kept as `pwsh-unstable` |
| `golang/go` | **mise**, next to the other language runtimes |
| `cpisciotta/xcbeautify` | **dropped** |
| `golang/tools/gorename` | **dropped** |

## The two that were dropped

- **`xcbeautify`** is macOS only and refuses to evaluate on `x86_64-linux`. It
  has never run on this machine.
- **`gorename`** was deleted upstream at x/tools v0.26.0
  ([golang/go#69360](https://github.com/golang/go/issues/69360)) because gopls
  covers renaming. gopls v0.23.0 is installed and registered as an LSP through
  mason-lspconfig; the nvim config never mentions `gorename`; and `gorename`
  appears **zero times in 71920 lines of shell history**, while `gopls` appears
  in the same file — so the count means "never run", not "no history".

## Verification

- `AQUA_CONFIG=<this branch> aqua list --installed` returns **nothing**, with
  no parse error on the three files that now declare nothing
- `mise latest go` resolves to **1.26.6**, the same version aqua had pinned
- `idiomatic_version_file_enable_tools` in the mise config already listed `go`,
  so the setting was in place before the tool was declared
- The mise config parses: `mise ls` against this branch exits 0

## Ordering and aftermath

The home-manager side is already merged and activated, so this can be applied
whenever. Nothing in use disappears — aqua's binaries stay on disk until aqua
is explicitly run, and every command still resolves.

After `chezmoi apply`, run `mise install` so `go` comes from mise rather than
the leftover aqua shim.

What to do with aqua itself — leave the config and binaries in place, or
uninstall and reclaim the 13 GB under `~/.local/share/aqua` — is now a
decidable question, and a separate one.
