### PR TITLE
fix(mise): declare dotnet with its fully qualified backend

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,6 +1,13 @@
 [tools]
 # single
-dotnet-core = "latest"
+# Fully qualified, like the geckodriver and chromedriver entries below. The
+# short names do not resolve on 2026.8.4: `dotnet-core` and `dotnet` both send
+# mise to ~/.local/share/mise/plugins/dotnet/bin/list-all, and `core:dotnet`
+# errors even though `mise registry` lists it. The failure surfaced as
+# "Failed to run .../bin/list-all" on every `mise upgrade`, which still exited
+# 0 -- so vup recorded a success while dotnet sat at 10.0.300 with no
+# executable on PATH.
+"asdf:mise-plugins/mise-dotnet" = "latest"
 erlang = "latest"
 # Moved off aqua. A language runtime belongs with the other runtimes, and
 # idiomatic_version_file_enable_tools below already listed go, so the setting


### PR DESCRIPTION
## 問題

`dotnet-core = "latest"` の宣言で、`mise upgrade` が毎回こう出していた。

```
mise WARN  Error getting latest version for dotnet: Failed to run ~/.local/share/mise/plugins/dotnet/bin/list-all: No such file or directory (os error 2)
```

**しかも exit 0 で終わるので、vup（pueue）からは成功に見える。** 実害は2つ。

- dotnet が 10.0.300 のまま更新されていなかった（最新は 10.0.400）
- `mise which dotnet` が `No executable found` を返し、**PATH に dotnet が出ていなかった**

## 原因

mise は asdf プラグインを**ツールの短い名前**で引く。`dotnet-core` と書いても探索先は `plugins/dotnet/bin/list-all` で、実体のプラグインディレクトリは `dotnet-core`。宣言と探索先が最初から噛み合っていない。

2026.8.4 では短縮形がどれも解決しない。

| 書き方 | 結果 |
|---|---|
| `dotnet-core` | `plugins/dotnet/bin/list-all` を探して失敗 |
| `dotnet` | 同上 |
| `core:dotnet` | `mise registry` には載っているがエラー |
| `asdf:mise-plugins/mise-dotnet` | **成功** |

## 解決策

完全修飾で宣言する。同じファイルの `"github:mozilla/geckodriver"` / `"http:chromedriver"` と同じ形。

## 検証

- `mise upgrade --dry-run` → `All tools are up to date`（WARN 消滅）
- `mise which dotnet` → `.../installs/asdf-mise-plugins-mise-dotnet/latest/dotnet`
- `dotnet --version` → `10.0.400`

## 別途、手作業が残る

旧宣言時代の `~/.local/share/mise/installs/dotnet-core`（613MB）が mise の管理から外れた孤児として残る。`mise uninstall` が「入っていない」と言うため、ディレクトリごと手で削除する。