### PR TITLE
fix(mise): put python's latest first so the PATH fix is not a downgrade

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -28,9 +28,13 @@ node = [
   "latest",
   "23",
 ]
+# `latest` first: mise takes the first entry of a multi-version list as the one
+# that lands on PATH, and 3.12 was only ever the default because /usr/bin won
+# outright -- see the fish_user_paths fix. Keeping 3.12 first would have made
+# that fix a downgrade from 3.14.7.
 python = [
-  "3.12",
   "latest",
+  "3.12",
   "3",
   "3.11",
   "3.13",


### PR DESCRIPTION
## Problem

mise takes the first entry of a multi-version list as the one that lands
on PATH. `python` had `"3.12"` first.

That never showed, because `/usr/bin` outranked every mise directory:
`python3` resolved to the system 3.14.7 regardless of what this file said.
Removing that promotion (mimikun.fish-config#8) makes the declaration
live — and with `"3.12"` first, `python3` would move from 3.14.7 back to
3.12.14.

## Solution

Reorder the list so `latest` comes first. 3.14.7 is already installed as
`latest`, so this installs nothing.

## Verification

With both changes in place, all five runtimes resolve from mise and none
regresses:

| | before | after |
|---|---|---|
| `lua` | 5.5.1 | **5.1** |
| `node` | v22.23.2 | **v24.19.0** |
| `ruby` | 3.4.10 | **4.0.6** |
| `python3` | 3.14.7 | **3.14.7** |
| `go` | `/usr/bin/go` | mise |