### PR TITLE
Drop the lint and format crates that moved to nixpkgs

### DIFF
--- a/dot_mimikun-pkglists/linux_cargo_packages.txt
+++ b/dot_mimikun-pkglists/linux_cargo_packages.txt
@@ -5,10 +5,8 @@ aichat
 aim
 amdtop
 apisnip
-ast-grep
 atac
 atuin
-bacon
 ballast
 bandwhich
 basalt-tui
@@ -47,8 +45,6 @@ code-minimap
 codeberg-cli
 colorgen-nvim
 comchan
-commitlint-rs
-committed
 concord
 confirm-pam
 countryfetch
@@ -92,9 +88,6 @@ ecscope
 eilmeldung
 ekphos
 elio
-emmylua_check
-emmylua_doc_cli
-emmylua_ls
 envex
 envfetch
 epiq
@@ -196,7 +189,6 @@ lobtui
 logria
 lsd
 lstr
-lychee
 macchina
 mairu
 mamediff
@@ -271,7 +263,6 @@ pumas
 punktf
 purple-ssh
 putzen-cli
-pylyzer
 qmassa
 qrtool
 rage
@@ -309,12 +300,10 @@ scraps
 sd
 seednaut
 seetui
-selene
 serie
 serpl
 sharedserver
 sheldon
-shellharden
 siggy
 sigrs
 sigye
@@ -337,7 +326,6 @@ starship
 starship-jj
 strace-tui
 stu
-stylua
 superseedr
 swaptop
 swpui
@@ -347,7 +335,6 @@ systemd-manager-tui
 systeroid
 syswatch
 t-rec
-taplo-cli
 tatuin
 tauri-cli
 taws
@@ -380,7 +367,6 @@ tui-journal
 tuisky
 tukai
 turm
-typos-cli
 typst-cli
 tzupdate
 usage-cli


### PR DESCRIPTION
The generated cargo package list still names fourteen crates that no longer come from cargo. `typos-cli`, `taplo-cli`, the three emmylua crates, `bacon`, `commitlint-rs`, `committed`, `lychee`, `pylyzer`, `selene`, `shellharden` and `stylua` are now declared in home-manager; `ast-grep` was already declared there by the pnpm migration and only had to leave cargo.

Regenerating the list dropped exactly those fourteen and nothing else, 411 to 397.

`treefmt` stays on cargo: nixpkgs carries only the Go rewrite while cargo has the Rust original, so that one is a rewrite to decide on rather than a move.

Companion to mimikun/mimikun.home-manager#11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux Cargo package list.
  * Removed obsolete package entries while retaining `atac` and `atuin`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->