### PR TITLE
feat(hooks): keep reasoning out of Todoist descriptions

### DIFF
--- a/dot_claude/hooks/executable_todoist-sync-reminder.sh
+++ b/dot_claude/hooks/executable_todoist-sync-reminder.sh
@@ -14,6 +14,13 @@
 # mobile apps, so any listing fetched earlier in the session can be stale by
 # the time a write goes out.
 #
+# Clause (4) is here for a different reason. Reasoning kept leaking into task
+# descriptions, duplicating what the agent-system record already holds, and the
+# copies drifted. Seven occurrences so far, and the last three were created
+# moments after this very hook fired — a note in a document only works when the
+# document is read, whereas this text is forced in immediately before the write.
+# The failure point is the moment of creation, so the reminder has to fire there.
+#
 # There is nothing here to regression-test, which is why the suite has no cases
 # for it. Changing the text is safe; producing invalid JSON is not, so the
 # payload is built with jq rather than written out by hand.
@@ -21,7 +28,7 @@
 set -euo pipefail
 
 read -r -d '' context <<'EOF' || true
-TODOIST SYNC RULE: the user also edits Todoist from desktop and mobile apps, so any listing fetched earlier in this session may already be stale. (1) BEFORE this write, re-fetch the target with find-tasks / get-overview unless you already did so in this same turn. (2) AFTER the write, re-fetch the same query and verify by count before claiming completion. (3) If this write creates or rewords a task and you have not already loaded the `todoist` skill in this session, load it now — it holds the end-condition format the task has to carry, and a task written without it has to be rewritten.
+TODOIST SYNC RULE: the user also edits Todoist from desktop and mobile apps, so any listing fetched earlier in this session may already be stale. (1) BEFORE this write, re-fetch the target with find-tasks / get-overview unless you already did so in this same turn. (2) AFTER the write, re-fetch the same query and verify by count before claiming completion. (3) If this write creates or rewords a task and you have not already loaded the `todoist` skill in this session, load it now — it holds the end-condition format the task has to carry, and a task written without it has to be rewritten. (4) The description field carries STEPS ONLY — what the user reads at the moment of doing the task (addresses, opening hours, a checklist, the procedure). Reasons, alternatives considered, comparisons and findings belong in the agent-system record and are referenced by a pointer, never copied here (M01). Move the content into the record BEFORE shrinking a description, not after.
 EOF
 
 jq -cn --arg c "$context" \


### PR DESCRIPTION
## Problem

Reasoning keeps leaking into Todoist task descriptions — why an option was chosen, what alternatives were rejected, what a test showed. The agent-system record already holds all of it, so the description becomes a second copy, and the two drift.

This has now happened seven times. The last three were written moments after this hook fired: the hook injects the sync rule and the skill pointer, but says nothing about what belongs in a description, so nothing stops it at the point where it goes wrong.

## Solution

Add clause (4) to the injected context: descriptions carry steps only — what gets read at the moment of doing the task. Reasons and findings stay in the record, referenced by a pointer.

The clause also states the ordering that was violated most recently: move content into the record *before* shrinking a description, not after. Doing it in the other order deletes the only copy.

A note in a document works when the document is read. This text is forced in immediately before the write, which is where the failure actually happens.

No new mechanism — one clause in an existing hook. Verified with `bash -n` and by piping the output through `jq`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Todoist sync reminder to keep task descriptions focused on actionable steps.
  * Supporting context, such as reasons and alternatives, is now referenced separately rather than included in task descriptions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->