### PR TITLE
feat(claude): set global output style to Concise

### DIFF
--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -277,6 +277,7 @@
   },
   "inputNeededNotifEnabled": true,
   "model": "opus",
+  "outputStyle": "Concise",
   "permissions": {
     "allow": [
       "Bash(npm:*)",


### PR DESCRIPTION
Claude Code の出力スタイルの既定が全プロジェクトで `default` のままで、リポジトリごとに `.claude/settings.local.json` へ `outputStyle` を書かないと Concise にならなかった。

`~/.claude/settings.json`（= `dot_claude/private_settings.json`）に `"outputStyle": "Concise"` を追加し、グローバル既定にする。リポジトリ側の `settings.local.json` は従来どおり上書きできる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added a concise output style setting for AI-generated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->