### PR TITLE
feat: install gws calendar skills

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_after-install-agent-skills.sh.tmpl
@@ -35,6 +35,15 @@ declare -A remote_skills=(
     ["convert-documents-to-markdown"]="firecrawl/anydoc"
     ["find-skills"]="vercel-labs/skills"
     ["gh-stack"]="github/gh-stack"
+    # googleworkspace/cli publishes 95 skills, one per API it covers. Only the
+    # calendar path is installed here: the other 91 would flood the skill list
+    # with APIs this machine never calls. gws-shared is not optional - the
+    # calendar skills open by telling the reader to go read it for auth and
+    # global flags, so leaving it out breaks them.
+    ["gws-calendar"]="googleworkspace/cli"
+    ["gws-calendar-agenda"]="googleworkspace/cli"
+    ["gws-calendar-insert"]="googleworkspace/cli"
+    ["gws-shared"]="googleworkspace/cli"
     ["herdr"]="ogulcancelik/herdr"
 )
 
@@ -89,6 +98,7 @@ check_cli() {
 }
 
 check_cli browser-use browser-use "https://github.com/browser-use/browser-use"
+check_cli gws         gws-calendar "https://github.com/googleworkspace/cli"
 check_cli herdr       herdr       "https://github.com/ogulcancelik/herdr"
 check_cli neowright   neowright   "https://github.com/isak102/neowright"
 check_cli officecli   officecli   "https://github.com/iOfficeAI/OfficeCLI"


### PR DESCRIPTION
`googleworkspace/cli` の上流スキル4つを `bunx skills` で導入する設定を追加。

## なぜ dotfiles に手書きせず、インストールスクリプトに載せるのか

`.chezmoiignore.tmpl` の allowlist は、手書きで抱える条件を
**"no upstream repo, no CLI that ships them"** と定めている。
gws は上流リポジトリがあり、さらに `gws generate-skills` で再生成できるので、
`use-spark` や `todoist` とは逆側 — 再インストール可能な側に属する。

## 95個のうち4個だけ入れる理由

`googleworkspace/cli` は API ごとに95個のスキルを配っている。
このマシンが呼ばない API の分までスキル一覧に並ぶのを避けるため、カレンダー経路だけに絞った。

`gws-shared` は任意ではない。カレンダー系スキルは冒頭で
「auth とグローバルフラグは gws-shared を読め」と指示しているため、外すと壊れる。

## 検証

- `chezmoi execute-template` で展開し `bash -n` 通過
- 4つとも実際に導入済み。再実行すると `already installed.` を返す（冪等）
- `check_cli gws` を追加。バイナリが無いときに警告が出る
- 個人情報の混入なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Workspace calendar skills for viewing agendas, inserting events, and managing calendars.
  * Added the shared functionality required by these calendar tools.

* **Bug Fixes**
  * Added a warning when the Google Workspace CLI is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->