### PR TITLE
chore(mcphub.nvim): drop unused playwright MCP server

### DIFF
--- a/dot_config/mcphub/servers.json
+++ b/dot_config/mcphub/servers.json
@@ -8,10 +8,6 @@
       "command": "uvx",
       "args": ["mcp-server-time"]
     },
-    "playwright": {
-      "command": "npx",
-      "args": ["-y", "@executeautomation/playwright-mcp-server"]
-    },
     "github": {
       "command": "github-mcp-server",
       "args": ["stdio"],


### PR DESCRIPTION
## 問題

`~/playwright-mcp-server.log` がホームディレクトリ直下に生成され続けていた。

`@executeautomation/playwright-mcp-server` はログ出力先を `${process.env.HOME}/playwright-mcp-server.log` にハードコードしており、パスもログレベルも設定で変更できない。`maxFiles: 5` のローテーション設定なので、10MB を超えると `.1`〜`.5` もホーム直下に増える。

mcphub.nvim が Neovim 起動ごとに stdio サーバとして spawn するため、履歴が蓄積していた。

## このサーバは使われていなかった

削除前のログ 600 行の内訳:

| メッセージ | 回数 |
| --- | --- |
| MCP Server starting up | 50 |
| ListTools / ListResources | 各 50 |
| CallTool（ツール実行） | 0 |

約 13 時間で 50 回起動し、ツール呼び出しは 0 件。ブラウザ操作は別系統で足りている。

## 変更

`servers.json` から `playwright` エントリを削除。

## 確認

`mcp-hub 4.2.1` を起動して spawn 対象を確認した。

```
fetch connected
time connected
github disconnected   # トークン未設定のため元から未接続
```

playwright は spawn されず、`~/playwright-mcp-server.log` は再生成されなかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Playwright MCP server configuration.
  * Existing fetch, time, GitHub, and native Neovim integrations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->