### PR TITLE
feat(claude): block master commits, master pushes, and PR merges

### DIFF
--- a/dot_claude/hooks/executable_deny-master-commit.sh
+++ b/dot_claude/hooks/executable_deny-master-commit.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny commits on master/main and pushes that
+# target master/main.
+#
+# rules/general.md says to use a feature branch and open a PR. That is a rule an
+# agent has to remember, and on 2026-08-26 one did not: the change landed as a
+# commit on master in the chezmoi source repo. A commit is not a publish step,
+# so the existing push guards never saw it. This hook removes the need to
+# remember.
+#
+# Two layers, in this order:
+#   1. parse  — find each git invocation and its subcommand, and read the
+#               destination refspec of a push
+#   2. repo   — which repository and which branch the command would act on
+#
+# The subcommand is parsed, not pattern-matched. `git log --grep commit` names
+# commit but does not run it, and a regex loose enough to see `git -C <dir>
+# commit` is also loose enough to see that.
+#
+# The repository is resolved from `git -C <dir>`, a leading `cd <dir>`, or the
+# hook's own cwd, in that order.
+#
+# Allowlist: mimikun.agent-system permits direct master commits by its own
+# AGENTS.md. Nothing else does.
+#
+# Unknown state allows. A detached HEAD cannot be identified as master, and the
+# dangerous half of that workflow is `git push origin HEAD:master`, which layer
+# 1 catches without asking git anything.
+#
+# Contract: print the deny payload and exit 0 when the command matches, print
+# nothing and exit 0 otherwise. Never exit non-zero — a failing hook aborts
+# commands it was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/master-commit.txt (parse layer)
+#        scripts/test-master-guard.sh (repo layer, needs git fixtures)
+
+set -uo pipefail
+
+deny() {
+    printf '%s' "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$1\"}}"
+    exit 0
+}
+
+unquote() {
+    local value=$1
+    value=${value%\"}
+    value=${value#\"}
+    value=${value%\'}
+    value=${value#\'}
+    printf '%s' "$value"
+}
+
+input=$(cat 2>/dev/null) || input=""
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || hook_cwd=""
+
+[ -n "$command" ] || exit 0
+
+# ---- layer 1: parse --------------------------------------------------------
+
+is_commit=0
+is_push=0
+push_targets_protected=0
+dir_flag=""
+cd_dir=""
+
+# Word splitting is the point here: the operators become their own tokens.
+read -r -a tokens <<<"${command//[;&|]/ & }"
+
+i=0
+count=${#tokens[@]}
+while [ "$i" -lt "$count" ]; do
+    token=${tokens[i]}
+    i=$((i + 1))
+
+    # `cd <dir>` at the head of a segment moves where a later git runs.
+    if [ "$token" = "cd" ] && [ "$i" -lt "$count" ] && [ -z "$cd_dir" ]; then
+        cd_dir=$(unquote "${tokens[i]}")
+        continue
+    fi
+
+    [ "$token" = "git" ] || continue
+
+    # Skip git's own options. These four take a separate argument.
+    while [ "$i" -lt "$count" ]; do
+        case ${tokens[i]} in
+            -C | -c | --git-dir | --work-tree | --namespace)
+                if [ "${tokens[i]}" = "-C" ] && [ $((i + 1)) -lt "$count" ]; then
+                    dir_flag=$(unquote "${tokens[i + 1]}")
+                fi
+                i=$((i + 2))
+                ;;
+            --git-dir=* | --work-tree=*)
+                i=$((i + 1))
+                ;;
+            -*)
+                i=$((i + 1))
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    [ "$i" -lt "$count" ] || break
+    subcommand=${tokens[i]}
+    i=$((i + 1))
+
+    case $subcommand in
+        commit) is_commit=1 ;;
+        push)
+            is_push=1
+            # A push names its destination, so a protected target is visible
+            # without asking git. Whole tokens only: feature-master-test is not
+            # master.
+            while [ "$i" -lt "$count" ]; do
+                case ${tokens[i]} in
+                    '&') break ;;
+                esac
+                target=$(unquote "${tokens[i]}")
+                case ${target##*:} in
+                    master | main | refs/heads/master | refs/heads/main)
+                        push_targets_protected=1
+                        ;;
+                esac
+                i=$((i + 1))
+            done
+            ;;
+    esac
+done
+
+[ "$is_commit" -eq 1 ] || [ "$is_push" -eq 1 ] || exit 0
+
+# ---- layer 2: repository and branch ---------------------------------------
+
+target_dir=${dir_flag:-${cd_dir:-$hook_cwd}}
+target_dir=${target_dir/#\~/$HOME}
+[ -n "$target_dir" ] || target_dir=$PWD
+
+toplevel=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null) || toplevel=""
+# Not a repository, or a path this hook cannot resolve: nothing to protect.
+[ -n "$toplevel" ] || exit 0
+
+# The one repository whose own AGENTS.md grants direct master commits.
+case ${toplevel##*/} in
+    mimikun.agent-system) exit 0 ;;
+esac
+
+branch=$(git -C "$target_dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || branch=""
+
+on_protected=0
+case $branch in
+    master | main) on_protected=1 ;;
+esac
+
+if [ "$is_commit" -eq 1 ] && [ "$on_protected" -eq 1 ]; then
+    deny "Committing on $branch is blocked in this repository. rules/general.md: branch, commit, push, open a PR. Start with: git switch -c <name>"
+fi
+
+if [ "$is_push" -eq 1 ] && { [ "$push_targets_protected" -eq 1 ] || [ "$on_protected" -eq 1 ]; }; then
+    deny "Pushing to master/main is blocked in this repository. rules/general.md: push a feature branch and open a PR instead."
+fi
+
+exit 0

--- a/dot_claude/hooks/executable_deny-pr-merge.sh
+++ b/dot_claude/hooks/executable_deny-pr-merge.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — deny merging a pull request.
+#
+# rules/general.md: merging is the owner's job, done by hand in the GitHub web
+# UI. An agent stops once the PR is open. Merging moves master, and the two
+# checks around that rule (read `git cherry`, count the commits afterwards)
+# exist to hand the owner something to decide with.
+#
+# The companion guard, deny-master-commit.sh, blocks commits on master and
+# pushes to master. `gh pr merge` reaches the same place through the API, so it
+# needs its own guard: git never sees it.
+#
+# Covers the subcommand and the `gh api` route to the same endpoint, since the
+# latter is what remains once the subcommand is blocked.
+#
+# Not covered: `berg` (Codeberg). Its merge syntax is not established here, and
+# a guessed pattern would deny the wrong commands. `git merge` is also out of
+# scope — a local merge is not a publish step.
+#
+# Contract: print the deny payload and exit 0 when the command matches, print
+# nothing and exit 0 otherwise. Never exit non-zero — a failing hook aborts
+# commands it was never meant to block.
+#
+# Cases: scripts/claude-hooks-cases/pr-merge.txt
+
+set -euo pipefail
+
+# Input that jq cannot parse must not abort the hook.
+command=$(jq -r '.tool_input.command // empty' 2>/dev/null) || command=""
+
+# The middle group carries gh's global flags (`gh --repo o/r pr merge`). Quotes
+# stop it, so a merge named inside a `--search` string is not a match.
+subcommand='gh[[:space:]]+([^;&|"'\'']*[[:space:]]+)?pr[[:space:]]+merge([[:space:]]|$)'
+api='gh[[:space:]]+([^;&|"'\'']*[[:space:]]+)?api([[:space:]]|$)'
+merge_endpoint='pulls/[^[:space:]/]+/merge'
+
+if printf '%s' "$command" | grep -Eq "$subcommand" ||
+    { printf '%s' "$command" | grep -Eq "$api" &&
+        printf '%s' "$command" | grep -Eq "$merge_endpoint"; }; then
+    printf '%s' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Merging a PR is the owner'\''s job, done by hand in the GitHub web UI. Stop once the PR is open and report its number."}}'
+fi

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -198,6 +198,15 @@
       {
         "hooks": [
           {
+            "command": "bash '/home/mimikun/.claude/hooks/deny-master-commit.sh'",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
             "command": "bash '/home/mimikun/.claude/hooks/deny-interpreter-oneliners.sh'",
             "type": "command"
           }

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -207,6 +207,15 @@
       {
         "hooks": [
           {
+            "command": "bash '/home/mimikun/.claude/hooks/deny-pr-merge.sh'",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
             "command": "bash '/home/mimikun/.claude/hooks/deny-interpreter-oneliners.sh'",
             "type": "command"
           }

--- a/scripts/claude-hooks-cases/pr-merge.txt
+++ b/scripts/claude-hooks-cases/pr-merge.txt
@@ -1,0 +1,40 @@
+# script: deny-pr-merge.sh
+#
+# Merging is the owner's job (rules/general.md). This guard is purely lexical,
+# so it belongs here rather than in scripts/test-master-guard.sh.
+#
+# DENY|<command>  or  allow|<command>
+
+DENY|gh pr merge
+DENY|gh pr merge 3705
+DENY|gh pr merge 3705 --rebase
+DENY|gh pr merge --squash --delete-branch
+DENY|gh pr merge --admin
+# global flags sit between gh and the subcommand
+DENY|gh --repo mimikun/dotfiles pr merge 3705
+DENY|gh -R mimikun/dotfiles pr merge
+# flags at the end of a compound command: prefix matching cannot see these
+DENY|cd /tmp && gh pr merge 3705
+DENY|git switch master; gh pr merge
+# the api route to the same endpoint, which is what is left once the subcommand is blocked
+DENY|gh api --method PUT repos/mimikun/dotfiles/pulls/3705/merge
+DENY|gh api -X PUT /repos/mimikun/dotfiles/pulls/3705/merge -f merge_method=rebase
+
+allow|gh pr create --title x --body y
+allow|gh pr view 3705
+allow|gh pr view 3705 --json state,mergeable
+allow|gh pr list --state open
+allow|gh pr checkout 3705
+allow|gh pr diff 3705
+allow|gh pr edit 3705 --title x
+# reading a PR through the api is not merging it
+allow|gh api repos/mimikun/dotfiles/pulls/3705
+allow|gh api repos/mimikun/dotfiles/pulls/3705/commits
+# an endpoint path without gh api is not a request
+allow|echo repos/mimikun/dotfiles/pulls/3705/merge >notes.txt
+# a local merge is not a publish step
+allow|git merge --ff-only origin/master
+allow|git status
+# merge named inside a quoted argument, not as a subcommand
+allow|gh pr list --search "pr merge"
+allow|gh issue list --search "merge"

--- a/scripts/test-master-guard.sh
+++ b/scripts/test-master-guard.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Regression tests for dot_claude/hooks/executable_deny-master-commit.sh.
+#
+# That hook decides from repository state — current branch, repository name — so
+# its cases cannot live in scripts/claude-hooks-cases/. The shared runner passes
+# a command string and nothing else, which would leave every case depending on
+# whichever branch the tester happened to be on. This script builds throwaway
+# repositories instead, so the answers are fixed.
+#
+# The hook body is never duplicated here, so this tests what actually runs. The
+# settings file is checked too: without that, a typo in the hook command leaves
+# every case passing against a script production never invokes.
+#
+# Usage: scripts/test-master-guard.sh
+#
+# Requires: bash 4+, jq, git.
+
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+hook="$repo_root/dot_claude/hooks/executable_deny-master-commit.sh"
+settings="$repo_root/dot_claude/private_settings.json"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
+[ -f "$hook" ] || { echo "hook not found: $hook" >&2; exit 2; }
+
+if ! jq -e '[.. | objects | .command? // empty] | any(test("deny-master-commit\\.sh"))' "$settings" >/dev/null; then
+    echo "deny-master-commit.sh is not referenced by $settings" >&2
+    exit 2
+fi
+
+tmp=$(mktemp -d) || exit 2
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/empty-template"
+
+new_repo() { # <path> <branch>
+    # --template: init.templateDir is set globally and installs git-secrets
+    # hooks into every new repository. A fixture must not depend on a tool the
+    # tester may not have installed.
+    git init -q -b "$2" --template="$tmp/empty-template" "$1"
+    git -C "$1" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+}
+
+new_repo "$tmp/on-master" master
+new_repo "$tmp/on-main" main
+new_repo "$tmp/on-feature" feat/x
+new_repo "$tmp/mimikun.agent-system" master
+new_repo "$tmp/detached" master
+git -C "$tmp/detached" checkout -q --detach HEAD
+mkdir -p "$tmp/plain"
+
+fail=0
+run=0
+
+check() { # <want> <cwd> <command>
+    run=$((run + 1))
+    local want=$1 cwd=$2 cmd=$3 out rc got
+    out=$(jq -cn --arg c "$cmd" --arg d "$cwd" \
+        '{tool_name: "Bash", cwd: $d, tool_input: {command: $c}}' | bash "$hook")
+    rc=$?
+
+    # A hook that exits non-zero aborts commands it was never meant to block.
+    if [ "$rc" -ne 0 ]; then
+        fail=$((fail + 1))
+        printf '  FAIL exit=%-3s %s\n' "$rc" "$cmd"
+        return
+    fi
+
+    [ -n "$out" ] && got=DENY || got=allow
+    if [ "$want" != "$got" ]; then
+        fail=$((fail + 1))
+        printf '  FAIL want=%-5s got=%-5s [%s] %s\n' "$want" "$got" "${cwd##*/}" "$cmd"
+    fi
+}
+
+# The commit that started this: on master, never pushed, invisible to the push
+# guards.
+check DENY "$tmp/on-master" 'git commit -m "chore: x"'
+check DENY "$tmp/on-master" 'git commit --amend --no-edit'
+check DENY "$tmp/on-main" 'git commit -m "chore: x"'
+check DENY "$tmp/on-master" 'git add -A && git commit -m "chore: x"'
+check DENY "$tmp/on-master" 'git push'
+check DENY "$tmp/on-master" 'git push -u origin master'
+
+# Feature branch: the whole point is that this stays out of the way.
+check allow "$tmp/on-feature" 'git commit -m "chore: x"'
+check allow "$tmp/on-feature" 'git push -u origin feat/x'
+check allow "$tmp/on-feature" 'git switch -c other'
+check allow "$tmp/on-feature" 'git status'
+check allow "$tmp/on-feature" 'git log --oneline -3'
+
+# The destination is visible without git, so a push names itself.
+check DENY "$tmp/on-feature" 'git push origin master'
+check DENY "$tmp/on-feature" 'git push origin HEAD:master'
+check DENY "$tmp/on-feature" 'git push origin feat/x:master'
+check DENY "$tmp/on-feature" 'git push origin refs/heads/main'
+check DENY "$tmp/on-feature" 'git push origin HEAD:refs/heads/master'
+
+# Branch names that merely contain the protected spellings.
+check allow "$tmp/on-feature" 'git push origin feature-master-test'
+check allow "$tmp/on-feature" 'git push origin HEAD:refs/heads/fix-main-menu'
+
+# A parsed subcommand, not a pattern match: these name commit without running it.
+check allow "$tmp/on-master" 'git log --grep commit'
+check allow "$tmp/on-master" 'git show --stat commit'
+check allow "$tmp/on-master" 'echo "git commit -m x" >notes.txt'
+
+# Where git will actually operate, not where the session happens to be.
+check DENY "$tmp/on-feature" "git -C $tmp/on-master commit -m x"
+check allow "$tmp/on-master" "git -C $tmp/on-feature commit -m x"
+check DENY "$tmp/plain" "cd $tmp/on-master && git commit -m x"
+check allow "$tmp/on-master" "cd $tmp/on-feature && git commit -m x"
+check DENY "$tmp/on-master" 'git -c user.name=t commit -m x'
+
+# mimikun.agent-system grants direct master commits in its own AGENTS.md.
+check allow "$tmp/mimikun.agent-system" 'git commit -m "chore: x"'
+check allow "$tmp/mimikun.agent-system" 'git push origin HEAD:master'
+
+# Nothing to protect, and nothing to crash on.
+check allow "$tmp/plain" 'git commit -m x'
+check allow "$tmp/detached" 'git commit -m x'
+check allow "$tmp/on-master" 'ls -la'
+check allow "$tmp/on-master" ''
+
+echo "---"
+if [ "$fail" -eq 0 ]; then
+    printf 'ok   master-guard %2d cases\n' "$run"
+else
+    printf 'FAIL master-guard %d of %d cases\n' "$fail" "$run"
+fi
+exit $((fail > 0))


### PR DESCRIPTION
## 問題

`rules/general.md` は「feature ブランチを使い、PR を出す」「マージは本人が WebUI で行う」と定めているが、どちらもエージェントが覚えていなければ守れない規則になっている。2026-08-26、前者が守られなかった。変更が chezmoi source リポジトリの master 上のコミットとして着地した。

**既存のガードでは検出できない。** `deny-destructive-push.sh` は force / mirror / delete / `+refspec` を見ており、`deny-destructive-git.sh` は `clean --force` と `reset --hard` を見ている。どちらも「publish する操作」を対象にしているが、**commit は publish ではない。** master 上のコミットは、push するまで、あるいは push しなくても、どのガードにも触れない。

同じことがマージにも当てはまる。`gh pr merge` は API 経由で master を動かすので、**git は一度もそれを見ない。**

## 変更

hook を2本追加し、`PreToolUse` (matcher: `Bash`) に登録する。1コミット1本。

### 1. `deny-master-commit.sh` — master への commit と push

deny:

- HEAD が `master` / `main` のときの `git commit`
- 宛先が `master` / `main` の `git push`（`origin master`、`HEAD:master`、`feat/x:master`、`refs/heads/main`）
- HEAD が `master` / `main` のときの引数なし `git push`

allow:

- feature ブランチ上の commit と push
- `feature-master-test` のように保護対象の綴りを含むだけのブランチ名
- `git log --grep commit` のように、サブコマンドではない位置に commit / push が現れるコマンド
- **`mimikun.agent-system`** — このリポジトリだけは自身の `AGENTS.md` で master 直コミットを許可している
- リポジトリ外、detached HEAD、状態を解決できないパス（**不明な状態は allow**）

**サブコマンドは正規表現ではなくパースする。** `git -C <dir> commit` を拾えるだけ緩い正規表現は、`git log --grep commit` も拾ってしまう。読み取り専用のコマンドを deny する仕組みは、回避策を覚えられて死ぬ。そのため git のオプションを読み飛ばし、最初の非オプショントークンをサブコマンドとして確定する（`-C` / `-c` / `--git-dir` / `--work-tree` / `--namespace` は引数を取るので、そこも合わせて飛ばす）。

対象リポジトリは `git -C <dir>` → 先頭の `cd <dir>` → hook 自身の cwd の順で解決する。

### 2. `deny-pr-merge.sh` — PR のマージ

deny:

- `gh pr merge`（`gh --repo o/r pr merge` のようにグローバルフラグが挟まる形も含む）
- `gh api` で `pulls/<n>/merge` を叩く形。**サブコマンドを塞いだ後に残る経路がこれ**

allow:

- `gh pr create` / `view` / `list` / `checkout` / `diff` / `edit`
- `gh api` で PR を読むだけのパス
- `git merge --ff-only`（ローカルのマージは publish ではない）
- `gh pr list --search "pr merge"` — 引用符が中間グループを止めるので、文字列の中の merge は一致しない

**対象外:** `berg`（Codeberg）。ここではマージ構文が確立しておらず、推測でパターンを書くと違うコマンドを deny する。

## テスト

### `scripts/claude-hooks-cases/pr-merge.txt`（25 ケース）

`deny-pr-merge.sh` は純粋に字句判定なので、既存の runner に収まる。

### `scripts/test-master-guard.sh`（32 ケース、新規スクリプト）

`deny-master-commit.sh` はリポジトリの状態（現在のブランチ、リポジトリ名）から判断するため、**既存の `scripts/claude-hooks-cases/` には置けない。** あの runner はコマンド文字列だけを渡すので、`git commit` のケースは「テスト実行者がたまたまどのブランチにいたか」で結果が変わってしまう。代わりに使い捨てのリポジトリを作って cwd ごと注入する。フィクスチャは `--template` で `init.templateDir` から隔離してある（グローバル設定が git-secrets のフックを入れるため）。

全スイート:

```
ok   destructive-git          24 cases
ok   destructive-push         30 cases
ok   interpreter-oneliners    28 cases
ok   pr-merge                 25 cases
ok   recursive-rm             31 cases
---
all 138 cases passed

ok   master-guard 32 cases
```

`shellcheck -s bash` は追加した両 hook でクリーン。

## 実地確認

今日実際に起きたコマンドを、本物のリポジトリに対して通した。

| cwd | コマンド | 結果 |
| --- | --- | --- |
| `~/.local/share/chezmoi` (master) | `git commit -q -m "chore(mcphub.nvim): ..."` | **deny** |
| feature ブランチの worktree | `git commit -m x` | allow |
| feature ブランチの worktree | `git push -u origin chore/deny-master-commit-hook` | allow |
| `mimikun.agent-system` (master) | `git commit -m "docs: ..."` | allow |
| — | `gh pr merge 3705 --rebase` | **deny** |
| — | `gh api --method PUT repos/mimikun/dotfiles/pulls/3705/merge` | **deny** |
| — | `gh pr view 3705 --json state` | allow |

1行目が、今日 deny されるべきだったコマンドそのもの。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that block commits and pushes targeting protected `main` or `master` branches.
  - Added a controlled exception for direct `master` commits in the designated repository.
  - Added safeguards that block GitHub pull-request merge commands.
  - Unrecognized or unrelated commands continue without interruption.

- **Bug Fixes**
  - Improved protection against unintended protected-branch updates and pull-request merges.

- **Tests**
  - Added coverage for commit, push, repository, branch, parsing, exemption, and pull-request merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->