### PR TITLE
docs(rules): drop the worktree and local branch once a PR is open

### DIFF
--- a/dot_claude/rules/general.md
+++ b/dot_claude/rules/general.md
@@ -94,7 +94,18 @@
 ```
 git worktree add ../<repo>-<desc> <branch>   # 作業 → commit → push
 git worktree remove ../<repo>-<desc>         # 終わったら必ず消す
+git branch -d <branch>                       # PR を出したら手元には残さない
 ```
+
+**push して PR を出した時点で、worktree もローカルブランチも不要。両方消す。**
+ブランチはリモートに残っており PR がそれを指しているので、手元の複製は**次に同じ
+ブランチ名で worktree を切ろうとしたときに邪魔になるだけ**。マージはユーザーが
+WebUI で行うので、手元のブランチがマージ後に自動で消えることもない。
+
+- **`git branch -d` が拒否したら、消さずに止まる。** `-d` は upstream と同一かを見るので、
+  拒否は「push し損ねたコミットがある」の意味。**`-D` で潰さない** — 先に何が残って
+  いるかを見ること
+- **リモートブランチは消さない。** PR がそれを参照している
 
 **`<branch>` が他の worktree でチェックアウト済みだと `worktree add` は失敗する。**
 master はほぼ常にこれに当たるので、master で作業するときは次の形にする。


### PR DESCRIPTION
## 問題

`rules/general.md` の「エージェントは worktree で作業する」は worktree の削除しか書いておらず、**ローカルブランチの行き先が未定義**だった。

マージは GitHub の WebUI で手動なので、ローカルブランチを消す契機がどこにも無い。溜まったブランチは、次に同じ名前で `worktree add` しようとしたときに詰まる原因になる。

実際に今日、`mimikun.nvim-config` の作業で「PR を出したあとブランチをどうするか」がルールに無く、その場で判断することになった。

## 変更

worktree セクションに、push + PR 完了が worktree とローカルブランチ両方の終了条件であることを明記した。

- コードブロックに `git branch -d <branch>` を追加
- `-d` が拒否したら**止まる**ことを明記。拒否は「push し損ねたコミットがある」の意味なので、`-D` で潰すと取りこぼす
- リモートブランチは消さない（PR が参照している）

`chezmoi add -S` で worktree 側へ入れているので、共有の source ディレクトリは触っていない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified post-worktree cleanup procedures after creating a pull request.
  - Added guidance to remove the associated local branch using standard Git commands.
  - Documented that remote branches should remain unchanged.
  - Added a safety check requiring work to stop if local branch deletion fails, helping prevent accidental loss of unpushed commits.
  - Removed unnecessary formatting from the instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->