### PR TITLE
fix(hooks): close the master-commit hole in deny-master-commit

### DIFF
--- a/dot_claude/hooks/executable_deny-master-commit.sh
+++ b/dot_claude/hooks/executable_deny-master-commit.sh
@@ -17,8 +17,14 @@
 # commit but does not run it, and a regex loose enough to see `git -C <dir>
 # commit` is also loose enough to see that.
 #
-# The repository is resolved from `git -C <dir>`, a leading `cd <dir>`, or the
-# hook's own cwd, in that order.
+# The repository is resolved from `git -C <dir>`, the `cd <dir>` in effect at
+# that point in the command, or the hook's own cwd, in that order.
+#
+# Layer 2 runs once per git invocation, not once per command, and a `cd` updates
+# the directory every git after it sees. Reading only the first `cd` and applying
+# it to the whole command got both answers wrong when a command changed directory
+# twice: `cd <feature> && git status; cd <master> && git commit` was allowed,
+# because the commit was judged against the feature checkout it never ran in.
 #
 # Allowlist: mimikun.agent-system permits direct master commits by its own
 # AGENTS.md. Nothing else does.
@@ -56,12 +62,46 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || hook_cwd
 
 [ -n "$command" ] || exit 0
 
+# ---- layer 2: repository and branch ---------------------------------------
+
+# Denies (and exits) when <kind> would act on a protected branch of the
+# repository containing <dir>. Called per git invocation, so a command that
+# changes directory partway is judged where each git actually runs.
+#   $1 kind             commit | push
+#   $2 dir              directory that git would run in
+#   $3 targets_protected  push only: 1 when the refspec names master/main
+check_git() {
+    local kind=$1 target_dir=$2 targets_protected=${3:-0}
+    local toplevel branch on_protected=0
+
+    target_dir=${target_dir/#\~/$HOME}
+    [ -n "$target_dir" ] || target_dir=$PWD
+
+    toplevel=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null) || toplevel=""
+    # Not a repository, or a path this hook cannot resolve: nothing to protect.
+    [ -n "$toplevel" ] || return 0
+
+    # The one repository whose own AGENTS.md grants direct master commits.
+    case ${toplevel##*/} in
+        mimikun.agent-system) return 0 ;;
+    esac
+
+    branch=$(git -C "$target_dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || branch=""
+    case $branch in
+        master | main) on_protected=1 ;;
+    esac
+
+    if [ "$kind" = commit ] && [ "$on_protected" -eq 1 ]; then
+        deny "Committing on $branch is blocked in this repository. rules/general.md: branch, commit, push, open a PR. Start with: git switch -c <name>"
+    fi
+
+    if [ "$kind" = push ] && { [ "$targets_protected" -eq 1 ] || [ "$on_protected" -eq 1 ]; }; then
+        deny "Pushing to master/main is blocked in this repository. rules/general.md: push a feature branch and open a PR instead."
+    fi
+}
+
 # ---- layer 1: parse --------------------------------------------------------
 
-is_commit=0
-is_push=0
-push_targets_protected=0
-dir_flag=""
 cd_dir=""
 
 # Word splitting is the point here: the operators become their own tokens.
@@ -73,13 +113,26 @@ while [ "$i" -lt "$count" ]; do
     token=${tokens[i]}
     i=$((i + 1))
 
-    # `cd <dir>` at the head of a segment moves where a later git runs.
-    if [ "$token" = "cd" ] && [ "$i" -lt "$count" ] && [ -z "$cd_dir" ]; then
-        cd_dir=$(unquote "${tokens[i]}")
+    # `cd <dir>` moves where every later git in the command runs. The most recent
+    # one wins: a shell does not forget the second `cd` because a first one ran.
+    if [ "$token" = "cd" ] && [ "$i" -lt "$count" ]; then
+        new_dir=$(unquote "${tokens[i]}")
+        case $new_dir in
+            # `&` is a segment break, so `cd` had no argument at all. `cd -`
+            # returns somewhere this hook cannot name; leave the last known
+            # directory in place rather than invent one.
+            '&' | -*) ;;
+            /* | '~'*) cd_dir=$new_dir ;;
+            # A relative hop composes onto wherever the command already is.
+            *) cd_dir=${cd_dir:+$cd_dir/}$new_dir ;;
+        esac
         continue
     fi
 
     [ "$token" = "git" ] || continue
+
+    # Per invocation: `git -C a commit; git commit` must not reuse a.
+    dir_flag=""
 
     # Skip git's own options. These four take a separate argument.
     while [ "$i" -lt "$count" ]; do
@@ -107,12 +160,14 @@ while [ "$i" -lt "$count" ]; do
     i=$((i + 1))
 
     case $subcommand in
-        commit) is_commit=1 ;;
+        commit)
+            check_git commit "${dir_flag:-${cd_dir:-$hook_cwd}}"
+            ;;
         push)
-            is_push=1
             # A push names its destination, so a protected target is visible
             # without asking git. Whole tokens only: feature-master-test is not
             # master.
+            push_targets_protected=0
             while [ "$i" -lt "$count" ]; do
                 case ${tokens[i]} in
                     '&') break ;;
@@ -125,40 +180,9 @@ while [ "$i" -lt "$count" ]; do
                 esac
                 i=$((i + 1))
             done
+            check_git push "${dir_flag:-${cd_dir:-$hook_cwd}}" "$push_targets_protected"
             ;;
     esac
 done
-
-[ "$is_commit" -eq 1 ] || [ "$is_push" -eq 1 ] || exit 0
-
-# ---- layer 2: repository and branch ---------------------------------------
-
-target_dir=${dir_flag:-${cd_dir:-$hook_cwd}}
-target_dir=${target_dir/#\~/$HOME}
-[ -n "$target_dir" ] || target_dir=$PWD
-
-toplevel=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null) || toplevel=""
-# Not a repository, or a path this hook cannot resolve: nothing to protect.
-[ -n "$toplevel" ] || exit 0
-
-# The one repository whose own AGENTS.md grants direct master commits.
-case ${toplevel##*/} in
-    mimikun.agent-system) exit 0 ;;
-esac
-
-branch=$(git -C "$target_dir" symbolic-ref --quiet --short HEAD 2>/dev/null) || branch=""
-
-on_protected=0
-case $branch in
-    master | main) on_protected=1 ;;
-esac
-
-if [ "$is_commit" -eq 1 ] && [ "$on_protected" -eq 1 ]; then
-    deny "Committing on $branch is blocked in this repository. rules/general.md: branch, commit, push, open a PR. Start with: git switch -c <name>"
-fi
-
-if [ "$is_push" -eq 1 ] && { [ "$push_targets_protected" -eq 1 ] || [ "$on_protected" -eq 1 ]; }; then
-    deny "Pushing to master/main is blocked in this repository. rules/general.md: push a feature branch and open a PR instead."
-fi
 
 exit 0

--- a/scripts/test-master-guard.sh
+++ b/scripts/test-master-guard.sh
@@ -112,6 +112,22 @@ check DENY "$tmp/plain" "cd $tmp/on-master && git commit -m x"
 check allow "$tmp/on-master" "cd $tmp/on-feature && git commit -m x"
 check DENY "$tmp/on-master" 'git -c user.name=t commit -m x'
 
+# A command that changes directory twice. Reading only the first `cd` and
+# applying it to the whole command answered both of these backwards: the guard
+# denied a commit that would land on a feature branch, and — the half that
+# matters — allowed one that would land on master.
+check allow "$tmp/plain" "cd $tmp/on-master && git status; cd $tmp/on-feature && git commit -m x"
+check DENY "$tmp/plain" "cd $tmp/on-feature && git status; cd $tmp/on-master && git commit -m x"
+check DENY "$tmp/plain" "cd $tmp/on-feature && git status; cd $tmp/on-master && git push"
+# A relative hop composes onto where the command already is.
+check DENY "$tmp/plain" "cd $tmp && cd on-master && git commit -m x"
+check allow "$tmp/plain" "cd $tmp && cd on-feature && git commit -m x"
+# -C belongs to one invocation and must not leak onto the next.
+check DENY "$tmp/on-feature" "git -C $tmp/on-feature status; git -C $tmp/on-master commit -m x"
+check allow "$tmp/on-master" "git -C $tmp/on-master status; git -C $tmp/on-feature commit -m x"
+# Every git in the command is judged, not just the last one.
+check DENY "$tmp/plain" "cd $tmp/on-master && git commit -m x; cd $tmp/on-feature && git commit -m y"
+
 # mimikun.agent-system grants direct master commits in its own AGENTS.md.
 check allow "$tmp/mimikun.agent-system" 'git commit -m "chore: x"'
 check allow "$tmp/mimikun.agent-system" 'git push origin HEAD:master'


### PR DESCRIPTION
## 問題

`deny-master-commit.sh` は**1コマンド内の最初の `cd` しか読まず**、それをそのコマンド内の全ての git 呼び出しに適用していた。

```bash
if [ "$token" = "cd" ] && [ "$i" -lt "$count" ] && [ -z "$cd_dir" ]; then
                                                   # ^^^^^^^^^^^^^ 最初の1回だけ
```

途中でディレクトリを変えるコマンドは、**その git が実際には走らないリポジトリ**に対して判定される。

git fixture（`repoA`=master、`repoB`=feature）で両方向を実測した結果:

| コマンド | commit が走る先 | 修正前 | 修正後 |
|---|---|---|---|
| `cd <feature> && git status; cd <master> && git commit` | **master** | **allow** ← 穴 | DENY |
| `cd <master> && git status; cd <feature> && git commit` | feature | DENY ← 誤検知 | allow |

**重要なのは1行目。** この hook が作られた理由そのもの（2026-08-26 の chezmoi master 直コミット）が、この形なら素通りしていた。

2行目の誤検知が発端で気づいた。`chezmoi` 本体（master）を見てから worktree（feature ブランチ）へ移って commit するコマンドが弾かれた。

## 変更

- layer 2 を `check_git()` に切り出し、**コマンドごとに1回ではなく git 呼び出しごとに**実行する
- `cd` は**直近のものが有効**（`-z` ガードを削除）。相対パスは積み上げる（`cd $tmp && cd on-master`）。`cd -` と引数なしの `cd` は名前を解決できないので直前の値を保つ
- `-C` を**呼び出しごとにリセット**。`git -C a status; git commit` が a を引き継がないように
- コマンド内の**全ての** git が判定対象になる（従来は最後の状態でまとめて1回）

## 検証

- `scripts/test-master-guard.sh`: **40 cases ok**（既存29 + 新規11）。新規は両方向・相対 `cd`・`-C` の漏れ・1コマンド2 commit をカバー
- `scripts/test-claude-hooks.sh`: 138 cases 全て ok（他の hook に影響なし）
- `shellcheck -S warning`: clean
- 実際にインストール済みの hook に対しても両ケースを流し、穴が塞がっていることを確認

`chezmoi add -S` で worktree を指しているので、共有 source ディレクトリは触っていない（`chezmoi diff` で差分なしを確認済み）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against commits and pushes targeting protected branches, including commands run after directory changes or with Git directory overrides.
  - Compound commands are now evaluated individually, preventing later protected operations from being overlooked.
  - Existing allowlisted repositories and unknown repository states continue to behave as expected.

- **Tests**
  - Added regression coverage for directory changes, relative paths, per-command Git directory settings, and mixed command sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->