### PR TITLE
chore(claude): sync herdr agent-state hook to integration v9

### DIFF
--- a/dot_claude/hooks/executable_herdr-agent-state.sh
+++ b/dot_claude/hooks/executable_herdr-agent-state.sh
@@ -3,7 +3,7 @@
 # managed by herdr; reinstalling or updating the integration overwrites this file.
 # add custom hooks beside this file instead of editing it.
 # HERDR_INTEGRATION_ID=claude
-# HERDR_INTEGRATION_VERSION=8
+# HERDR_INTEGRATION_VERSION=9
 
 set -eu
 
@@ -48,14 +48,13 @@ if hook_input_file:
     except Exception:
         hook_input = {}
 
+if "CURSOR_VERSION" in os.environ or "cursor_version" in hook_input:
+    raise SystemExit(0)
 hook_event_name = str(hook_input.get("hook_event_name") or "")
+if hook_event_name != "SessionStart":
+    raise SystemExit(0)
 is_subagent = bool(hook_input.get("agent_id"))
 if is_subagent:
-    raise SystemExit(0)
-if hook_event_name == "SubagentStop":
-    # SubagentStop is a completion event. Older Herdr integrations mapped it
-    # to durable working, but Claude recap/away-summary can emit it after the
-    # main turn has already stopped. Never let it revive an idle pane.
     raise SystemExit(0)
 request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
 report_seq = time.time_ns()


### PR DESCRIPTION
## 問題

`chezmoi apply` すると `.claude/hooks/herdr-agent-state.sh` に毎回差分が出る。

herdr がローカルのファイルを integration v9 に更新していたが、chezmoi の source 側は
v8 のままだった。そのため apply するたびに v8 へ巻き戻そうとしていた。

## 対応

`chezmoi add` でローカル（新しい方）を source に取り込んだ。

差分の中身:

- `HERDR_INTEGRATION_VERSION` を 8 → 9
- Cursor 環境での早期 exit を追加
- `SessionStart` 以外のイベントを一律で早期 exit（v8 の `SubagentStop` 個別対応を置き換え）

## 注意

このファイルは herdr 自身が生成・上書きするもの（先頭コメントに明記されている）。
herdr を更新するたびに同じ drift が出るので、更新後は `chezmoi add` が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY7Lg4ycsMGqHCqskpJnMP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the Claude hook integration to the latest version.
  - Improved compatibility by skipping processing in Cursor-related environments and for unsupported input.
  - Limited hook processing to session-start events.
- **Behavior Changes**
  - Removed handling for subagent-stop events; subagent events continue to be excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->