### PR TITLE
fix(claude): skip hooks whose binary is not installed

### DIFF
--- a/dot_claude/hooks/executable_run-if-installed.sh
+++ b/dot_claude/hooks/executable_run-if-installed.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run a hook command only when it is actually installed.
+#
+# Optional tooling (rtk, lazy-tmux, git-ai) is wired into settings.json for
+# every tool call. When one of them is not installed, the hook fails and the
+# error is reported on each call. Skipping quietly keeps the wiring in place
+# for machines where the tool exists.
+#
+# Usage: run-if-installed.sh <command> [args...]
+set -uo pipefail
+
+cmd="${1:-}"
+[[ -n "$cmd" ]] || exit 0
+shift
+
+if [[ "$cmd" == */* ]]; then
+	[[ -x "$cmd" ]] || exit 0
+else
+	command -v "$cmd" >/dev/null 2>&1 || exit 0
+fi
+
+exec "$cmd" "$@"

--- a/dot_claude/private_settings.json
+++ b/dot_claude/private_settings.json
@@ -95,7 +95,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state awaiting_decision",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state awaiting_decision",
             "type": "command"
           }
         ],
@@ -104,7 +104,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state awaiting_input",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state awaiting_input",
             "type": "command"
           }
         ],
@@ -115,7 +115,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
             "type": "command"
           }
         ]
@@ -125,7 +125,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
             "type": "command"
           }
         ],
@@ -134,7 +134,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
             "type": "command"
           }
         ]
@@ -144,7 +144,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin",
             "type": "command"
           }
         ],
@@ -153,7 +153,7 @@
       {
         "hooks": [
           {
-            "command": "rtk hook claude",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' rtk hook claude",
             "type": "command"
           }
         ],
@@ -225,7 +225,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
             "type": "command"
           }
         ]
@@ -267,7 +267,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state idle",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state idle",
             "type": "command"
           }
         ]
@@ -286,7 +286,7 @@
       {
         "hooks": [
           {
-            "command": "/home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
+            "command": "bash '/home/mimikun/.claude/hooks/run-if-installed.sh' /home/mimikun/.local/bin/lazy-tmux hook claude-status --state working",
             "type": "command"
           }
         ]


### PR DESCRIPTION
## 問題

`rtk` / `lazy-tmux` / `git-ai` の3つが settings.json の hook に登録されているが、
このマシンにはどれもインストールされていない。

- `/home/mimikun/.git-ai/bin/git-ai` — ディレクトリごと存在しない
- `/home/mimikun/.local/bin/lazy-tmux` — 存在しない（設定 `~/.config/lazy-tmux` だけある）
- `rtk` — PATH 上に無い

PreToolUse / PostToolUse は毎ツール呼び出しで走るので、1回のツール実行ごとに
2〜3件の hook エラーが出続けていた。

## 対応

`~/.claude/hooks/run-if-installed.sh` を追加し、該当10コマンドをこれ経由にした。

- コマンドが無ければ exit 0（静かにスキップ）
- あれば `exec` するので、終了コードと stdin/stdout はそのまま透過

インストール済みのマシンでは挙動が変わらないので、hook の登録を消さずに済む。

## 検証

- `scripts/test-claude-hooks.sh` — 138 cases 全通過
- ラッパー単体: 絶対パス欠落 / PATH 欠落 / 存在するコマンド の3ケースを確認
- `chezmoi apply -S` で適用済み（実体と source に drift 無し）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLG6kHpqoLpYPPGQ1qq1xi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conditional command execution for configured hooks, allowing them to run only when the required command is available.
  - Added support for executing installed commands with their existing arguments.

- **Bug Fixes**
  - Hooks now exit quietly when no command is provided or a requested command is unavailable.
  - Updated configured hook commands to use the conditional execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->