### PR TITLE
feat(claude): install the tools the hooks call at setup time

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_after-install-claude-hook-tools.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_after-install-claude-hook-tools.sh.tmpl
@@ -1,0 +1,104 @@
+{{ if (eq .chezmoi.os "linux") -}}
+
+#!/bin/bash
+
+# The three tools private_settings.json wires into its Claude Code hooks.
+#
+# Every hook there names its binary by a fixed path, so a machine without the
+# binary ran a command that did not exist -- on every single tool call. Nothing
+# in this repository installed them: the settings travelled here while the
+# binaries were only ever put on one machine by hand.
+#
+# On the Azusa machine these come from mimikun.home-manager instead, which links
+# the same paths into the Nix store. The `-e` checks below see those links and
+# skip, so the two mechanisms never fight over a path. Versions are pinned to
+# what that repository declares -- bump one side and you must bump the other,
+# or the machines drift apart again, which is the whole problem this fixes.
+
+set -uo pipefail
+
+# A failed download leaves the tool missing rather than aborting the apply. The
+# hook that wanted it is one status notification, not something worth stopping a
+# machine's whole setup over.
+install_release() {
+	name="$1"
+	bin_path="$2"
+	url="$3"
+	want_sha="$4"
+	# empty means the asset is the binary itself, not an archive holding one
+	member="$5"
+
+	if [[ -e "$bin_path" ]]; then
+		echo "$name is already installed."
+		return 0
+	fi
+
+	echo "Installing $name"
+	tmp="$(mktemp -d)" || return 0
+
+	if ! curl -fsSL -o "$tmp/asset" "$url"; then
+		echo "$name: download failed, skipping" >&2
+		cleanup_tmp "$tmp"
+		return 0
+	fi
+
+	# The asset arrives over the network and is then executed on every tool
+	# call, so the hash is checked rather than trusted.
+	got_sha="$(sha256sum "$tmp/asset" | cut -d' ' -f1)"
+	if [[ "$got_sha" != "$want_sha" ]]; then
+		echo "$name: sha256 mismatch, refusing to install" >&2
+		echo "  want $want_sha" >&2
+		echo "  got  $got_sha" >&2
+		cleanup_tmp "$tmp"
+		return 0
+	fi
+
+	if [[ -n "$member" ]]; then
+		if ! tar xzf "$tmp/asset" -C "$tmp" "$member"; then
+			echo "$name: could not extract $member, skipping" >&2
+			cleanup_tmp "$tmp"
+			return 0
+		fi
+		mv "$tmp/$member" "$tmp/asset"
+	fi
+
+	mkdir -p "$(dirname "$bin_path")"
+	install -m755 "$tmp/asset" "$bin_path"
+	cleanup_tmp "$tmp"
+	echo "$name installed to $bin_path"
+}
+
+# The directory only ever holds the files above, so removing them by name is
+# enough and avoids a recursive delete on a path built from a variable.
+cleanup_tmp() {
+	rm -f "$1"/* 2>/dev/null
+	rmdir "$1" 2>/dev/null
+	return 0
+}
+
+# rtk is the one hook written as a plain command name, so it has to land
+# somewhere on PATH rather than at a path the settings spell out.
+install_release \
+	"rtk" \
+	"$HOME/.local/bin/rtk" \
+	"https://github.com/rtk-ai/rtk/releases/download/v0.45.0/rtk-x86_64-unknown-linux-musl.tar.gz" \
+	"c4c036fbf181fc55ef329786c8c17e0d427972b053b825944d968a6aafef1ba4" \
+	"rtk"
+
+install_release \
+	"lazy-tmux" \
+	"$HOME/.local/bin/lazy-tmux" \
+	"https://github.com/alchemmist/lazy-tmux/releases/download/v0.2.1/lazy-tmux_linux_amd64.tar.gz" \
+	"ec3d100fd5d297f2f91660977692c24f238896ae265999b32aede8fd1e91c2fa" \
+	"lazy-tmux"
+
+install_release \
+	"git-ai" \
+	"$HOME/.git-ai/bin/git-ai" \
+	"https://github.com/git-ai-project/git-ai/releases/download/v1.7.2/git-ai-linux-x64" \
+	"3c28b74348ff78132fb42bc8e7fe4dc2f090ebeb431793ea706b5e5319d71571" \
+	""
+
+# vim:ft=bash.chezmoitmpl
+
+{{ end -}}


### PR DESCRIPTION
## 問題

`dot_claude/private_settings.json` は `rtk` / `lazy-tmux` / `git-ai` を計10箇所のフックから、**固定パスで**呼んでいる。

```
/home/mimikun/.local/bin/lazy-tmux hook claude-status --state working
/home/mimikun/.git-ai/bin/git-ai checkpoint claude --hook-input stdin
rtk hook claude
```

**このリポジトリのどこにも、この3つを入れる経路が無い。**設定だけが chezmoi で全マシンに配られ、バイナリは1台に手で入れた実体があるだけだった。他のマシンでは、**ツール呼び出しのたびに存在しないコマンドを実行していた。**

## 解決

`.chezmoiscripts/linux/run_onchange_after-install-claude-hook-tools.sh.tmpl` を追加。**既存の `run_onchange_after-install-*` 15本と同じ形。**設定と一緒にツールも届くようにする。

呼び出しごとにガードを挟むのではなく、**セットアップの時点で入れてしまう。**そうすれば「入っていないマシンがある」という前提そのものが消える。

| ツール | 置き先 | 版 |
|---|---|---|
| `rtk` | `~/.local/bin/rtk` | 0.45.0 |
| `lazy-tmux` | `~/.local/bin/lazy-tmux` | 0.2.1 |
| `git-ai` | `~/.git-ai/bin/git-ai` | 1.7.2 |

置き先は**今 settings.json が書いているパスに合わせてある**ので、設定側の変更は不要。

### 設計の理由

- **版は `mimikun.home-manager` の宣言に固定。**片方だけ上げるとマシン間でずれる（それがこの問題の出どころ）。スクリプト冒頭のコメントに両方上げるよう書いてある
- **sha256 を検証する。**ネットワークから取ったバイナリが以後**毎ツール呼び出しで実行される**ので、信用せず照合する。既存スクリプトの `curl \| sh` より強い
- **`-e` で既存をスキップ。**Azusa では home-manager が同じパスを Nix store にリンクするので、**2つの仕組みが同じファイルを取り合わない**（[mimikun.home-manager#40](https://github.com/mimikun/mimikun.home-manager/pull/40)）
- **ダウンロード失敗・ハッシュ不一致は、そのツールだけ飛ばして apply を続行。**ステータス通知1つのために、マシンのセットアップ全体を止める価値は無い

## 検証

テンプレートを展開して `shellcheck` (exit 0)、その後まっさらな `HOME` で実行:

```
Installing rtk
rtk installed to .../.local/bin/rtk
Installing lazy-tmux
lazy-tmux installed to .../.local/bin/lazy-tmux
Installing git-ai
git-ai installed to .../.git-ai/bin/git-ai
```

```
rtk 0.45.0
lazy-tmux 0.2.1 (linux/amd64, go1.26.5)
1.7.2
```

2回目の実行（冪等性）:

```
rtk is already installed.
lazy-tmux is already installed.
git-ai is already installed.
```

異常系（ハッシュを故意に壊し、URL を 404 に差し替え）:

```
rtk: sha256 mismatch, refusing to install
  want 0000...
  got  c4c0...
curl: (22) The requested URL returned error: 404
lazy-tmux: download failed, skipping
git-ai installed to .../.git-ai/bin/git-ai
exit=0
```

**壊れた2つは入らず、残り1つは入り、exit 0 で apply は続く。**一時ディレクトリの残骸も無し。

## 関連

**#3719 は取り下げてよい。**あちらは同じ問題に対して「呼び出しのたびに存在チェックして静かに飛ばす」ラッパを足す案で、入手元が不明だった時点の暫定策だった。入手元が判明した今、**セットアップで入れるほうが上流の対処**になる。ラッパを残すと、フックが無言で無効なまま気づけない状態も残る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2EZHJRqmD4m2jNGwYbeqb